### PR TITLE
Add sign-in web security and user details interceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>lfp-pay-web</artifactId>
-    <version>0d72a94</version>
+    <version>b7b93d0</version>
     <packaging>jar</packaging>
 
     <name>lfp-pay-web</name>
@@ -25,8 +25,16 @@
         <structured-logging.version>1.5.0-rc2</structured-logging.version>
         <common-web-java.version>1.0.1-rc3</common-web-java.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
+        <java-session-handler.version>2.2.0</java-session-handler.version>
+        <web-security-java.version>1.1.0-rc1</web-security-java.version>
+        <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
+        <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
 
-
+        <!-- Maven and Surefire plugins -->
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
     </properties>
 
     <dependencies>
@@ -69,6 +77,47 @@
             <version>${common-web-java.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>java-session-handler</artifactId>
+            <version>${java-session-handler.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>web-security-java</artifactId>
+            <version>${web-security-java.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Security dependencies -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -77,8 +126,43 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit-platform-surefire-provider.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit-platform-surefire-provider.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <fork>true</fork>
+                    <meminitial>128m</meminitial>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <maxmem>512m</maxmem>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/src/main/java/uk/gov/companieshouse/web/lfp/LFPWebApplication.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/LFPWebApplication.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.web.lfp;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.web.lfp.interceptor.UserDetailsInterceptor;
 
 
 @SpringBootApplication
@@ -10,8 +13,19 @@ public class LFPWebApplication implements WebMvcConfigurer {
 
     public static final String APPLICATION_NAME_SPACE = "lfp-pay-web";
 
+    private UserDetailsInterceptor userDetailsInterceptor;
+
+    @Autowired
+    public LFPWebApplication(UserDetailsInterceptor userDetailsInterceptor) {
+        this.userDetailsInterceptor = userDetailsInterceptor;
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(LFPWebApplication.class, args);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userDetailsInterceptor);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/lfp/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/interceptor/UserDetailsInterceptor.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.web.lfp.interceptor;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.web.lfp.session.SessionService;
+
+@Component
+public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
+
+    private static final String USER_EMAIL = "userEmail";
+
+    private static final String SIGN_IN_KEY = "signin_info";
+    private static final String USER_PROFILE_KEY = "user_profile";
+    private static final String EMAIL_KEY = "email";
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
+
+        if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
+                (request.getMethod().equalsIgnoreCase("POST") &&
+                        !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX)))) {
+
+            Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
+            Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
+            if (signInInfo != null) {
+                Map<String, Object> userProfile = (Map<String, Object>) signInInfo
+                        .get(USER_PROFILE_KEY);
+                modelAndView.addObject(USER_EMAIL, userProfile.get(EMAIL_KEY));
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.web.lfp.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import uk.gov.companieshouse.auth.filter.UserAuthFilter;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+import uk.gov.companieshouse.auth.filter.HijackFilter;
+
+@EnableWebSecurity
+public class WebSecurity extends WebSecurityConfigurerAdapter {
+
+    @Configuration
+    @Order(1)
+    public static class LFPWebSecurityFilterConfig extends WebSecurityConfigurerAdapter {
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+
+            http.addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
+                    .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class)
+                    .addFilterBefore(new UserAuthFilter(), BasicAuthenticationFilter.class);
+        }
+    }
+
+}
+

--- a/src/main/java/uk/gov/companieshouse/web/lfp/session/SessionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/session/SessionService.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.web.lfp.session;
+
+import java.util.Map;
+
+/**
+ * The {@code SessionService} interface provides an abstraction that can be
+ * used when testing {@code SessionHandler} static methods, without imposing
+ * the use of a test framework that supports mocking of static methods.
+ */
+public interface SessionService {
+
+    /**
+     * Returns a map comprising data retrieved from the current session.
+     *
+     * @return a map of session data
+     */
+    Map<String, Object> getSessionDataFromContext();
+}

--- a/src/main/java/uk/gov/companieshouse/web/lfp/session/impl/SessionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/session/impl/SessionServiceImpl.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.web.lfp.session.impl;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+import uk.gov.companieshouse.web.lfp.session.SessionService;
+
+import java.util.Map;
+
+@Component
+public class SessionServiceImpl implements SessionService {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Object> getSessionDataFromContext() {
+
+        return SessionHandler.getSessionDataFromContext();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/lfp/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/interceptor/UserDetailsInterceptorTests.java
@@ -1,0 +1,118 @@
+package uk.gov.companieshouse.web.lfp.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.ModelAndView;
+import uk.gov.companieshouse.web.lfp.session.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+public class UserDetailsInterceptorTests {
+
+    private static final String USER_EMAIL = "userEmail";
+
+    private static final String SIGN_IN_KEY = "signin_info";
+    private static final String USER_PROFILE_KEY = "user_profile";
+    private static final String EMAIL_KEY = "email";
+
+    private static final String TEST_EMAIL_ADDRESS = "test_email_address";
+
+    private static final Map<String, Object> userProfile = new HashMap<>();
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private HttpServletResponse httpServletResponse;
+
+    @Mock
+    private ModelAndView modelAndView;
+
+    @Mock
+    private SessionService sessionService;
+
+    @InjectMocks
+    private UserDetailsInterceptor userDetailsInterceptor;
+
+    @Test
+    @DisplayName("Tests the interceptor adds the user email to the model for GET requests")
+    void postHandleForGetRequestSuccess() throws Exception {
+        userProfile.put(EMAIL_KEY, TEST_EMAIL_ADDRESS);
+
+        Map<String, Object> signInInfo = new HashMap<>();
+        signInInfo.put(USER_PROFILE_KEY, userProfile);
+
+        Map<String, Object> sessionData = new HashMap<>();
+        sessionData.put(SIGN_IN_KEY, signInInfo);
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(sessionData);
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.GET.toString());
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, times(1)).addObject(USER_EMAIL, TEST_EMAIL_ADDRESS);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor adds the user email to the model for POST requests which don't redirect")
+    void postHandleForPostRequestError() throws Exception {
+        userProfile.put(EMAIL_KEY, TEST_EMAIL_ADDRESS);
+
+        Map<String, Object> signInInfo = new HashMap<>();
+        signInInfo.put(USER_PROFILE_KEY, userProfile);
+
+        Map<String, Object> sessionData = new HashMap<>();
+        sessionData.put(SIGN_IN_KEY, signInInfo);
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(sessionData);
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(modelAndView.getViewName()).thenReturn("error");
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, times(1)).addObject(USER_EMAIL, TEST_EMAIL_ADDRESS);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor does not add the user email to the model for POST requests")
+    void postHandleForPostRequestIgnored() throws Exception {
+
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(modelAndView.getViewName()).thenReturn("redirect:abc");
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, never()).addObject(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor does not add the user email to the model if no sign in info is available")
+    void postHandleForGetRequestWithoutSignInInfoIgnored() throws Exception {
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(new HashMap<>());
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.GET.toString());
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, never()).addObject(anyString(), any());
+    }
+}
+
+


### PR DESCRIPTION
- Forces the User to be logged in when using LFP service
- Displays user details at the top of page
- Added plugin to pom.xml to run unit tests

Resolves: LFA-520