### PR TITLE
Add Validation for Penalty Number on Penalty Details screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/annotation/Penalty.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/annotation/Penalty.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.web.lfp.annotation;
+
+import uk.gov.companieshouse.web.lfp.validation.PenaltyValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = PenaltyValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@ReportAsSingleViolation
+public @interface Penalty {
+
+    String message() default "You must enter a penalty reference";
+
+    String messageNotLongEnough() default "Enter your penalty reference exactly as shown on your penalty letter";
+
+    int stringSize() default Integer.MAX_VALUE;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/EnterLFPDetailsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/EnterLFPDetailsController.java
@@ -43,8 +43,6 @@ public class EnterLFPDetailsController extends BaseController {
     public String postLFPEnterDetails(@ModelAttribute("enterLFPDetails") @Valid EnterLFPDetails enterLFPDetails,
                                       BindingResult bindingResult, Model model) {
 
-        addBackPageAttributeToModel(model);
-
         if (bindingResult.hasErrors()) {
             return getTemplateName();
         }

--- a/src/main/java/uk/gov/companieshouse/web/lfp/models/EnterLFPDetails.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/models/EnterLFPDetails.java
@@ -5,18 +5,28 @@ import javax.validation.constraints.Pattern;
 
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.companieshouse.web.lfp.annotation.Penalty;
 
 @Getter
 @Setter
 public class EnterLFPDetails {
 
     /**
-     * Allows any length of number e.g "6400" is allowed.
+     * Returns different error messages depending on entered penalty.
+     * No entered penalty returns `message`
+     * Entered penalty but not a matching length to stringSize returns `messageNotLongEnough`
+     */
+    @Penalty(messageNotLongEnough = "{enterLfpDetails.penaltyNumber.wrongLength}",
+            message = "{enterLfpDetails.penaltyNumber.emptyField}",
+            stringSize = 8)
+    private String penaltyNumber;
+
+    /**
+     * Allows any length of number under 8. e.g "6400" is allowed.
      * Only allows letters if the total length is 8.
      * Doesn't allow spaces or empty strings
      */
     @NotNull
     @Pattern(regexp = "^([a-zA-Z0-9]{8}|[0-9]{1,8})$", message = "{enterLfpDetails.companyNumber.wrongLength}")
-
     private String companyNumber;
 }

--- a/src/main/java/uk/gov/companieshouse/web/lfp/validation/PenaltyValidator.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/validation/PenaltyValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.web.lfp.validation;
+
+import org.thymeleaf.util.StringUtils;
+import uk.gov.companieshouse.web.lfp.annotation.Penalty;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PenaltyValidator implements ConstraintValidator<Penalty, String> {
+
+    private int stringSize;
+    private String message;
+    private String messageNotLongEnough;
+
+    @Override
+    public void initialize(Penalty penalty) {
+        stringSize = penalty.stringSize();
+        message = penalty.message();
+        messageNotLongEnough = penalty.messageNotLongEnough();
+    }
+
+    @Override
+    public boolean isValid(String penaltyNumber, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if(penaltyNumber == null || StringUtils.isEmpty(penaltyNumber)) {
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+            return false;
+        } else if (penaltyNumber.length() != stringSize) {
+            context.buildConstraintViolationWithTemplate(messageNotLongEnough).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,1 +1,4 @@
 enterLfpDetails.companyNumber.wrongLength=You must enter your full eight character company number
+
+enterLfpDetails.penaltyNumber.emptyField = You must enter a penalty reference
+enterLfpDetails.penaltyNumber.wrongLength = Enter your penalty reference exactly as shown on your penalty letter

--- a/src/main/resources/templates/lfp/details.html
+++ b/src/main/resources/templates/lfp/details.html
@@ -39,15 +39,28 @@
                                    id="company-ref"
                                    th:field="*{companyNumber}"
                                    th:errorclass="govuk-input--error"
-                                   name="penalty-ref"
+                                   name="company-ref"
                                    type="text"
                                    maxlength="8">
                         </div>
-                        <div class="govuk-form-group">
+                        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('penaltyNumber')} ? 'govuk-form-group--error' : ''">
                             <label class="govuk-label" for="penalty-ref">
                                 Penalty reference
                             </label>
-                            <input class="govuk-input govuk-input--width-20" id="penalty-ref" name="penalty-ref" type="text">
+
+                            <span class="govuk-error-message"
+                                  id="penaltyNumber-errorId"
+                                  th:if="${#fields.hasErrors('penaltyNumber')}"
+                                  th:each="e : ${#fields.errors('penaltyNumber')}" th:text="${e}">
+                            </span>
+
+                            <input class="govuk-input govuk-input--width-10"
+                                   id="penalty-ref"
+                                   th:field="*{penaltyNumber}"
+                                   th:errorclass="govuk-input--error"
+                                   name="penalty-ref"
+                                   type="text"
+                                   maxlength="8">
                         </div>
                         <div class="govuk-form-group">
                             <details class="govuk-details">

--- a/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/EnterLFPDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/EnterLFPDetailsControllerTest.java
@@ -1,0 +1,174 @@
+package uk.gov.companieshouse.web.lfp.controller.lfp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.web.lfp.service.lfp.EnterLFPDetailsService;
+import uk.gov.companieshouse.web.lfp.service.navigation.NavigatorService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EnterLFPDetailsControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private EnterLFPDetailsService mockEnterLFPDetailsService;
+
+    @Mock
+    private NavigatorService mockNavigatorService;
+
+    @InjectMocks
+    private EnterLFPDetailsController controller;
+
+    private static final String ENTER_LFP_DETAILS_PATH = "/lfp/enter-details";
+
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+
+    private static final String ENTER_LFP_DETAILS_VIEW = "lfp/details";
+
+    private static final String ENTER_LFP_DETAILS_MODEL_ATTR = "enterLFPDetails";
+    
+    private static final String PENALTY_NUMBER_ATTRIBUTE = "penaltyNumber";
+
+    private static final String COMPANY_NUMBER_ATTRIBUTE = "companyNumber";
+    
+    private static final String VALID_PENALTY_OR_COMPANY_NUMBER = "12345678";
+
+    private static final String SIX_DIGIT_PENALTY_OR_COMPANY_NUMBER = "123456";
+
+    private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
+
+    private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
+
+    @BeforeEach
+    private void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("Get LFP Details view success path")
+    void getRequestSuccess() throws Exception {
+
+        when(mockNavigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+
+        this.mockMvc.perform(get(ENTER_LFP_DETAILS_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ENTER_LFP_DETAILS_VIEW))
+                .andExpect(model().attributeExists(ENTER_LFP_DETAILS_MODEL_ATTR))
+                .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
+    }
+
+    @Test
+    @DisplayName("Post LFP Details failure path - Blank company number, correct penalty number")
+    void postRequestCompanyNumberBlank() throws Exception {
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH)
+                .param(PENALTY_NUMBER_ATTRIBUTE, VALID_PENALTY_OR_COMPANY_NUMBER))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ENTER_LFP_DETAILS_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, COMPANY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 1));
+    }
+
+    @Test
+    @DisplayName("Post LFP Details failure path - correct company number, blank penalty number")
+    void postRequestPenaltyNumberBlank() throws Exception {
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH)
+                .param(COMPANY_NUMBER_ATTRIBUTE, VALID_PENALTY_OR_COMPANY_NUMBER))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ENTER_LFP_DETAILS_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, PENALTY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 1));
+    }
+
+    @Test
+    @DisplayName("Post LFP Details failure path - blank company number, blank penalty number")
+    void postRequestPenaltyNumberBlankAndCompanyNumberBlank() throws Exception {
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ENTER_LFP_DETAILS_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, PENALTY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, COMPANY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 2));
+    }
+
+    @Test
+    @DisplayName("Post LFP Details failure path - blank company number, incorrect penalty number length")
+    void postRequestPenaltyNumberIncorrectLengthAndCompanyNumberBlank() throws Exception {
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH)
+                .param(PENALTY_NUMBER_ATTRIBUTE, SIX_DIGIT_PENALTY_OR_COMPANY_NUMBER))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ENTER_LFP_DETAILS_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, PENALTY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeHasFieldErrors(ENTER_LFP_DETAILS_MODEL_ATTR, COMPANY_NUMBER_ATTRIBUTE))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 2));
+    }
+
+    @Test
+    @DisplayName("Post LFP Details success path")
+    void postRequestSuccess() throws Exception {
+
+        // Will need to be invoked when next page is added.
+        // when(mockNavigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH)
+                .param(PENALTY_NUMBER_ATTRIBUTE, VALID_PENALTY_OR_COMPANY_NUMBER)
+                .param(COMPANY_NUMBER_ATTRIBUTE, VALID_PENALTY_OR_COMPANY_NUMBER))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 0))
+
+                // Temporary NextController test until next page is added.
+                // .andExpect(view().name(MOCK_CONTROLLER_PATH));
+                .andExpect(view().name("redirect:null"));
+
+        verify(mockEnterLFPDetailsService, times(1)).appendToCompanyNumber(VALID_PENALTY_OR_COMPANY_NUMBER);
+    }
+
+    @Test
+    @DisplayName("Post LFP Details success path - 6 digit company number, correct penalty number")
+    void postRequestSuccess6DigitCompanyNumber() throws Exception {
+
+        // Will need to be invoked when next page is added.
+        // when(mockNavigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+
+        this.mockMvc.perform(post(ENTER_LFP_DETAILS_PATH)
+                .param(PENALTY_NUMBER_ATTRIBUTE, VALID_PENALTY_OR_COMPANY_NUMBER)
+                .param(COMPANY_NUMBER_ATTRIBUTE, SIX_DIGIT_PENALTY_OR_COMPANY_NUMBER))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeErrorCount(ENTER_LFP_DETAILS_MODEL_ATTR, 0))
+
+                // Temporary NextController test until next page is added.
+                // .andExpect(view().name(MOCK_CONTROLLER_PATH));
+                .andExpect(view().name("redirect:null"));
+
+        verify(mockEnterLFPDetailsService, times(1)).appendToCompanyNumber(SIX_DIGIT_PENALTY_OR_COMPANY_NUMBER);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/lfp/service/lfp/impl/EnterLFPDetailsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/service/lfp/impl/EnterLFPDetailsServiceImplTest.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.web.lfp.service.lfp.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.web.lfp.service.lfp.EnterLFPDetailsService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EnterLFPDetailsServiceImplTest {
+
+    @InjectMocks
+    private EnterLFPDetailsService enterLFPDetailsService = new EnterLFPDetailsServiceImpl();
+
+    private static final String COMPANY_NUMBER_WITH_LETTERS = "SE123456";
+
+    private static final String COMPANY_NUMBER_WITH_EIGHT_DIGITS = "12345678";
+
+    private static final String COMPANY_NUMBER_WITH_SIX_DIGITS = "123456";
+
+    private static final String APPENDED_SIX_DIGIT_COMPANY_NUMBER = "00123456";
+
+    @Test
+    @DisplayName("Append - Do not append to company number with letters")
+    void validateCompanyNumberWithLettersNotAppended() throws Exception {
+
+        String companyNumber = enterLFPDetailsService.appendToCompanyNumber(COMPANY_NUMBER_WITH_LETTERS);
+        assertEquals(companyNumber, COMPANY_NUMBER_WITH_LETTERS);
+    }
+
+    @Test
+    @DisplayName("Append - Eight Digit company number returned the same")
+    void validationEightDigitCompanyNumberReturnedTheSame() throws Exception {
+
+        String companyNumber = enterLFPDetailsService.appendToCompanyNumber(COMPANY_NUMBER_WITH_EIGHT_DIGITS);
+        assertEquals(companyNumber, COMPANY_NUMBER_WITH_EIGHT_DIGITS);
+    }
+
+    @Test
+    @DisplayName("Append - Six Digit company number should have 0's appended to beginning")
+    void validationSixDigitCompanyNumberReturnedWithAppendedZeros() throws Exception {
+
+        String companyNumber = enterLFPDetailsService.appendToCompanyNumber(COMPANY_NUMBER_WITH_SIX_DIGITS);
+        assertEquals(companyNumber, APPENDED_SIX_DIGIT_COMPANY_NUMBER);
+    }
+}


### PR DESCRIPTION
- Added validation to check that Penalty Number is 8 digits long on the 'Tell us your Penalty Details' screen. 
- Added limit to Penalty Number textbox limiting it to 8 characters. 
- Added unit tests for LFPDetails controller and service. 

Resolves LFA-253