### PR TITLE
Fixed error screens to be displayed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/service/latefilingpenalty/impl/LateFilingPenaltyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/service/latefilingpenalty/impl/LateFilingPenaltyServiceImpl.java
@@ -51,7 +51,7 @@ public class LateFilingPenaltyServiceImpl implements LateFilingPenaltyService {
         // Always include penalty with the ID provided so the correct error page can be displayed.
         for (LateFilingPenalty lateFilingPenalty: lateFilingPenalties.getItems()) {
             if ((!lateFilingPenalty.getPaid() && lateFilingPenalty.getType().equals(PENALTY_TYPE))
-                    && lateFilingPenalty.getId().equals(penaltyNumber)) {
+                    || lateFilingPenalty.getId().equals(penaltyNumber)) {
                 payableLateFilingPenalties.add(lateFilingPenalty);
             }
         }

--- a/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesControllerTest.java
@@ -150,6 +150,23 @@ public class ViewPenaltiesControllerTest {
     }
 
     @Test
+    @DisplayName("Get View LFP - late filing penalty is already paid")
+    void getRequestLateFilingPenaltyIsPaid() throws Exception {
+
+        configurePreviousController();
+        configurePaidPenalty(COMPANY_NUMBER, PENALTY_NUMBER);
+        configureValidCompanyProfile(COMPANY_NUMBER);
+
+        this.mockMvc.perform(get(VIEW_PENALTIES_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
+
+        verify(mockCompanyService, times(1)).getCompanyProfile(COMPANY_NUMBER);
+        verify(mockLateFilingPenaltyService, times(1)).getLateFilingPenalties(COMPANY_NUMBER, PENALTY_NUMBER);
+
+    }
+
+    @Test
     @DisplayName("Post View LFP - success path")
     void postRequestSuccess() throws Exception {
 
@@ -255,6 +272,14 @@ public class ViewPenaltiesControllerTest {
 
         when(mockLateFilingPenaltyService.getLateFilingPenalties(companyNumber, penaltyNumber))
                 .thenReturn(nullLFP);
+    }
+
+    private void configurePaidPenalty(String companyNumber, String penaltyNumber) throws ServiceException {
+        List<LateFilingPenalty> paidLFP = new ArrayList<>();
+        paidLFP.add(LFPTestUtility.paidLateFilingPenalty(penaltyNumber));
+
+        when(mockLateFilingPenaltyService.getLateFilingPenalties(companyNumber, penaltyNumber))
+                .thenReturn(paidLFP);
     }
 
     private void configureValidCompanyProfile(String companyNumber) throws ServiceException {


### PR DESCRIPTION
- Fixed error screens that weren't displaying correctly.
- Added logic to stop ViewPenaltiesController from being directly accessed for invalid penalties
- Added unit test for above logic 

Resolves LFA-893
