### PR TITLE
Add Jacoco for unit test coverage stats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <sdk-manager-java.version>1.4.0-rc1</sdk-manager-java.version>
         <api-sdk-java.version>4.1.22</api-sdk-java.version>
         <spring-test.version>5.1.3.RELEASE</spring-test.version>
+        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
 
         <!-- Maven and Surefire plugins -->
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
@@ -183,6 +184,26 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <maxmem>512m</maxmem>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Jacoco needs to be used for SonarQube to correctly display unit test coverage (it's currently displaying 0% coverage) 