### PR TITLE
Redirect users coming from govuk to sign in page

### DIFF
--- a/src/main/resources/templates/lfp/home.html
+++ b/src/main/resources/templates/lfp/home.html
@@ -32,9 +32,6 @@
                 </p>
 
                 <div class="form-group">
-                    <span th:if="${#httpServletRequest.getParameter('start') == 0}">
-                        <input type="hidden" id="hidden-button" class="piwik-event" data-event-id="lfp - GovUk Redirect"/>
-                    </span>
                     <input id="next-button" class="govuk-button" data-event-id="lfp - Start now" onclick="_paq.push(['trackGoal', 3]);" type="submit" role="button" value="Start now"/>
                 </div>
 

--- a/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartControllerTest.java
@@ -52,6 +52,7 @@ public class LFPStartControllerTest {
     }
 
     private static final String LFP_START_PATH = "/late-filing-penalty";
+    private static final String LFP_START_PATH_PARAM = "/late-filing-penalty?start=0";
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
     private static final String LFP_START_VIEW = "lfp/home";
@@ -104,6 +105,20 @@ public class LFPStartControllerTest {
 
         verify(mockLateFilingPenaltyService, times(1)).checkFinanceSystemAvailableTime();
 
+    }
+
+    @Test
+    @DisplayName("Get View Start Page - redirect to sign in")
+    void getRequestRedirectToSignInWhenVisitFromGovUk() throws Exception {
+
+        configureValidFinanceHealthcheckResponse();
+        configureNextController();
+
+        this.mockMvc.perform(get(LFP_START_PATH_PARAM))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(MOCK_CONTROLLER_PATH));
+
+        verify(mockLateFilingPenaltyService, times(1)).checkFinanceSystemAvailableTime();
     }
 
     @Test


### PR DESCRIPTION
- Redirect users to the sign in page when they visit the page through GovUk so that users do not see the start screen twice
-Add code to track the lfp start page if users are redirected to sign in screen

Resolves : BI-4835