### PR TITLE
SAN-63 Add FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,21 @@ In order to run this Web App locally you will need to install:
 
 ### Configuration
 
- Key                            | Description                                             
---------------------------------|---------------------------------------------------------
- `PPS_PAY_WEB_PORT`             | The port of the penalty-payment-web application         
- `HUMAN_LOG`                    | For human readable logs                                 
- `CH_BANK_ACC_NAME`             | Bacs payments - Account name (late filing penalty: A)   
- `CH_BANK_SORT_CODE`            | Bacs payments - Sort code (late filing penalty: A)      
- `CH_BANK_ACC_NUM`              | Bacs payments - Account number (late filing penalty: A) 
- `CH_BANK_IBAN`                 | Overseas payments - IBAN (late filing penalty: A)       
- `CH_BANK_SWIFT_CODE`           | Overseas payments - SWIFT code (late filing penalty: A) 
- `CH_SANCTIONS_BANK_ACC_NAME`   | Bacs payments - Account name (sanction: PN)             
- `CH_SANCTIONS_BANK_SORT_CODE`  | Bacs payments - Sort code (sanction: PN)                
- `CH_SANCTIONS_BANK_ACC_NUM`    | Bacs payments - Account number (sanction: PN)           
- `CH_SANCTIONS_BANK_IBAN`       | Overseas payments - IBAN (sanction: PN)                 
- `CH_SANCTIONS_BANK_SWIFT_CODE` | Overseas payments - SWIFT code (sanction: PN)           
+ Key                                                 | Description                                             
+-----------------------------------------------------|---------------------------------------------------------
+ `PPS_PAY_WEB_PORT`                                  | The port of the penalty-payment-web application         
+ `HUMAN_LOG`                                         | For human readable logs                                 
+ `CH_BANK_ACC_NAME`                                  | Bacs payments - Account name (late filing penalty: A)   
+ `CH_BANK_SORT_CODE`                                 | Bacs payments - Sort code (late filing penalty: A)      
+ `CH_BANK_ACC_NUM`                                   | Bacs payments - Account number (late filing penalty: A) 
+ `CH_BANK_IBAN`                                      | Overseas payments - IBAN (late filing penalty: A)       
+ `CH_BANK_SWIFT_CODE`                                | Overseas payments - SWIFT code (late filing penalty: A) 
+ `CH_SANCTIONS_BANK_ACC_NAME`                        | Bacs payments - Account name (sanction: PN)             
+ `CH_SANCTIONS_BANK_SORT_CODE`                       | Bacs payments - Sort code (sanction: PN)                
+ `CH_SANCTIONS_BANK_ACC_NUM`                         | Bacs payments - Account number (sanction: PN)           
+ `CH_SANCTIONS_BANK_IBAN`                            | Overseas payments - IBAN (sanction: PN)                 
+ `CH_SANCTIONS_BANK_SWIFT_CODE`                      | Overseas payments - SWIFT code (sanction: PN)           
+ `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224` | Feature flag to enable Penalty Payment for Sanctions    
 
 ### Web Pages
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/config/FeatureFlagConfigurationProperties.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/FeatureFlagConfigurationProperties.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.web.pps.config;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("feature-flag")
+public class FeatureFlagConfigurationProperties {
+
+    private Map<String, Boolean> penaltyRefEnabled = emptyMap();
+
+    public Map<String, Boolean> getPenaltyRefEnabled() {
+        return penaltyRefEnabled;
+    }
+
+    public void setPenaltyRefEnabled(Map<String, Boolean> penaltyRefEnabled) {
+        this.penaltyRefEnabled = penaltyRefEnabled;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
@@ -2,50 +2,28 @@ package uk.gov.companieshouse.web.pps.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
-import uk.gov.companieshouse.web.pps.PPSWebApplication;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 
 @Configuration
 @ConfigurationProperties("penalty")
 public class PenaltyConfigurationProperties {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PPSWebApplication.APPLICATION_NAME_SPACE);
-
-    private List<String> allowedRefStartsWith = new ArrayList<>();
+    private List<PenaltyReference> allowedRefStartsWith = new ArrayList<>();
     private String refStartsWithPath;
     private String enterDetailsPath;
     private String bankTransferWhichPenaltyPath;
     private String bankTransferLateFilingDetailsPath;
     private String bankTransferSanctionsPath;
 
-    public List<String> getAllowedRefStartsWith() {
+    public List<PenaltyReference> getAllowedRefStartsWith() {
         return allowedRefStartsWith;
     }
 
-    public void setAllowedRefStartsWith(List<String> allowedRefStartsWith) {
-        this.allowedRefStartsWith = filterAllowedRefStartsWithByEnum(allowedRefStartsWith);
-    }
-
-    private static List<String> filterAllowedRefStartsWithByEnum(
-            List<String> allowedRefStartsWith) {
-        return allowedRefStartsWith
-                .stream()
-                .map(startsWith -> {
-                    try {
-                        return PenaltyReference.fromStartsWith(startsWith).getStartsWith();
-                    } catch (IllegalArgumentException e) {
-                        LOGGER.info("Penalty Configuration - allowedRefStartsWith '" + startsWith
-                                + "' is invalid, ignoring for 'penaltyRefStartsWith' screen");
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toList();
+    public void setAllowedRefStartsWith(
+            List<PenaltyReference> allowedRefStartsWith) {
+        this.allowedRefStartsWith = allowedRefStartsWith;
     }
 
     public String getRefStartsWithPath() {

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
+
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.stereotype.Controller;
@@ -10,30 +12,36 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.pps.annotation.PreviousController;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.controller.BaseController;
 import uk.gov.companieshouse.web.pps.models.PenaltyReferenceChoice;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
+import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 
 @Controller
 @PreviousController(StartController.class)
 @RequestMapping("/late-filing-penalty/bank-transfer/which-penalty-service")
 public class BankTransferPenaltyReferenceController extends BaseController {
-    private static final String PPS_BANK_TRANSFER_PENALTY_REFERENCE = "pps/bankTransferPenaltyReference";
 
-    static final String PPS_AVAILABLE_PENALTY_REF_ATTR = "availablePenaltyReference";
-    static final String PPS_PENALTY_REF_ATTR = "penaltyReferences";
+    static final String PPS_BANK_TRANSFER_PENALTY_REFERENCE = "pps/bankTransferPenaltyReference";
+    static final String AVAILABLE_PENALTY_REF_ATTR = "availablePenaltyReference";
+    static final String PENALTY_REFERENCE_CHOICE_ATTR = "penaltyReferences";
 
     private final PenaltyConfigurationProperties penaltyConfigurationProperties;
+    private final List<PenaltyReference> availablePenaltyReference;
 
     public BankTransferPenaltyReferenceController(
             NavigatorService navigatorService,
-            PenaltyConfigurationProperties penaltyConfigurationProperties) {
+            PenaltyConfigurationProperties penaltyConfigurationProperties,
+            FeatureFlagChecker featureFlagChecker) {
         this.navigatorService = navigatorService;
         this.penaltyConfigurationProperties = penaltyConfigurationProperties;
+        availablePenaltyReference = penaltyConfigurationProperties.getAllowedRefStartsWith()
+                .stream()
+                .filter(featureFlagChecker::isPenaltyRefEnabled)
+                .toList();
     }
 
     @Override
@@ -43,9 +51,8 @@ public class BankTransferPenaltyReferenceController extends BaseController {
 
     @GetMapping
     public String getPenaltyReference(Model model) {
-        model.addAttribute(PPS_AVAILABLE_PENALTY_REF_ATTR,
-                penaltyConfigurationProperties.getAllowedRefStartsWith());
-        model.addAttribute(PPS_PENALTY_REF_ATTR, new PenaltyReferenceChoice());
+        model.addAttribute(AVAILABLE_PENALTY_REF_ATTR, availablePenaltyReference);
+        model.addAttribute(PENALTY_REFERENCE_CHOICE_ATTR, new PenaltyReferenceChoice());
 
         addBackPageAttributeToModel(model);
 
@@ -54,7 +61,7 @@ public class BankTransferPenaltyReferenceController extends BaseController {
 
     @PostMapping
     public String postPenaltyReference(
-            @Valid @ModelAttribute(PPS_PENALTY_REF_ATTR) PenaltyReferenceChoice penaltyReferenceChoice,
+            @Valid @ModelAttribute(PENALTY_REFERENCE_CHOICE_ATTR) PenaltyReferenceChoice penaltyReferenceChoice,
             BindingResult bindingResult,
             Model model
     ) {
@@ -63,22 +70,16 @@ public class BankTransferPenaltyReferenceController extends BaseController {
             for (FieldError error : errors) {
                 LOGGER.error(error.getObjectName() + " - " + error.getDefaultMessage());
             }
-            model.addAttribute(PPS_AVAILABLE_PENALTY_REF_ATTR,
-                    penaltyConfigurationProperties.getAllowedRefStartsWith());
+            model.addAttribute(AVAILABLE_PENALTY_REF_ATTR, availablePenaltyReference);
             return getTemplateName();
         }
 
-        String penaltyRefChoiceString = penaltyReferenceChoice.getSelectedPenaltyReference();
-        String redirectUrlPrefix = UrlBasedViewResolver.REDIRECT_URL_PREFIX;
+        String bankTransferPath = switch (penaltyReferenceChoice.getSelectedPenaltyReference()) {
+            case LATE_FILING -> penaltyConfigurationProperties.getBankTransferLateFilingDetailsPath();
+            case SANCTIONS -> penaltyConfigurationProperties.getBankTransferSanctionsPath();
+        };
 
-        if (penaltyRefChoiceString.equals(PenaltyReference.LATE_FILING.getStartsWith())) {
-            return redirectUrlPrefix
-                    + penaltyConfigurationProperties.getBankTransferLateFilingDetailsPath();
-        } else if (penaltyRefChoiceString.equals(PenaltyReference.SANCTIONS.getStartsWith())) {
-            return redirectUrlPrefix
-                    + penaltyConfigurationProperties.getBankTransferSanctionsPath();
-        }
-        return ERROR_VIEW;
+        return REDIRECT_URL_PREFIX + bankTransferPath;
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsController.java
@@ -1,9 +1,14 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
+import static java.lang.Boolean.FALSE;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.pps.controller.BaseController;
+import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 
 @Controller
 @RequestMapping("/late-filing-penalty/bank-transfer/sanctions-details")
@@ -11,12 +16,18 @@ public class BankTransferSanctionsDetailsController extends BaseController {
 
     private static final String BANK_TRANSFER_SANCTIONS_DETAILS = "pps/bankTransferSanctionsDetails";
 
+    @Autowired
+    private FeatureFlagChecker featureFlagChecker;
+
     @Override protected String getTemplateName() {
         return BANK_TRANSFER_SANCTIONS_DETAILS;
     }
 
     @GetMapping
     public String getBankTransferSanctionsDetails() {
+        if (FALSE.equals(featureFlagChecker.isPenaltyRefEnabled(SANCTIONS))) {
+            return ERROR_VIEW;
+        }
         return getTemplateName();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/EnterDetailsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/EnterDetailsController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
+import static java.lang.Boolean.FALSE;
 import static java.util.Locale.UK;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,6 +27,7 @@ import uk.gov.companieshouse.web.pps.exception.ServiceException;
 import uk.gov.companieshouse.web.pps.models.EnterDetails;
 import uk.gov.companieshouse.web.pps.service.company.CompanyService;
 import uk.gov.companieshouse.web.pps.service.penaltypayment.PenaltyPaymentService;
+import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 import uk.gov.companieshouse.web.pps.validation.EnterDetailsValidator;
 
@@ -49,6 +51,9 @@ public class EnterDetailsController extends BaseController {
     @Autowired
     private MessageSource messageSource;
 
+    @Autowired
+    private FeatureFlagChecker featureFlagChecker;
+
     private static final String NO_PENALTY_FOUND = "/no-penalties-found";
 
     private static final String PENALTY_PAID = "/penalty-paid";
@@ -69,6 +74,11 @@ public class EnterDetailsController extends BaseController {
     @GetMapping
     public String getEnterDetails(@RequestParam("ref-starts-with") String penaltyReferenceName,
             Model model) {
+
+        if (FALSE.equals(featureFlagChecker.isPenaltyRefEnabled(PenaltyReference.valueOf(penaltyReferenceName)))) {
+            return ERROR_VIEW;
+        }
+
         var enterDetails = new EnterDetails();
         enterDetails.setPenaltyReferenceName(penaltyReferenceName);
         model.addAttribute(ENTER_DETAILS_MODEL_ATTR, enterDetails);

--- a/src/main/java/uk/gov/companieshouse/web/pps/models/PenaltyReferenceChoice.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/models/PenaltyReferenceChoice.java
@@ -1,16 +1,19 @@
 package uk.gov.companieshouse.web.pps.models;
 
 import jakarta.validation.constraints.NotNull;
+import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 
 public class PenaltyReferenceChoice {
-    @NotNull(message = "Select what the penalty reference starts with")
-    private String selectedPenaltyReference;
 
-    public String getSelectedPenaltyReference() {
+    @NotNull(message = "{penaltyReferenceChoice.selectedPenaltyReference.notNull}")
+    private PenaltyReference selectedPenaltyReference;
+
+    public PenaltyReference getSelectedPenaltyReference() {
         return selectedPenaltyReference;
     }
 
-    public void setSelectedPenaltyReference(String selectedPenaltyReference) {
+    public void setSelectedPenaltyReference(PenaltyReference selectedPenaltyReference) {
         this.selectedPenaltyReference = selectedPenaltyReference;
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/util/FeatureFlagChecker.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/util/FeatureFlagChecker.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.web.pps.util;
+
+import static java.lang.Boolean.TRUE;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
+
+@Component
+public class FeatureFlagChecker {
+
+    private final FeatureFlagConfigurationProperties featureFlagConfigurationProperties;
+
+    public FeatureFlagChecker(FeatureFlagConfigurationProperties featureFlagConfigurationProperties) {
+        this.featureFlagConfigurationProperties = featureFlagConfigurationProperties;
+    }
+
+    public Boolean isPenaltyRefEnabled(PenaltyReference penaltyReference) {
+        return featureFlagConfigurationProperties.getPenaltyRefEnabled().getOrDefault(penaltyReference.name(), TRUE);
+    }
+
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,7 +1,7 @@
-enterDetails.companyNumber.notValid=Enter the company number
+penaltyReferenceChoice.selectedPenaltyReference.notNull=Select what the penalty reference starts with
 
+enterDetails.companyNumber.notValid=Enter the company number
 enterDetails.penaltyRef.notEmpty.LATE_FILING=Enter the reference number
 enterDetails.penaltyRef.notValid.LATE_FILING=Enter your reference number exactly as shown on your penalty letter
-
 enterDetails.penaltyRef.notEmpty.SANCTIONS=Enter the penalty reference
 enterDetails.penaltyRef.notValid.SANCTIONS=Enter your penalty reference exactly as shown on your penalty letter

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,10 @@ chBankAccNumber=${CH_BANK_ACC_NUM}
 chBankSortCode=${CH_BANK_SORT_CODE}
 chBankAccName=${CH_BANK_ACC_NAME}
 
-penalty.allowed-ref-starts-with[0]=A
-penalty.allowed-ref-starts-with[1]=PN
+feature-flag.penalty-ref-enabled.SANCTIONS=${FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224:false}
+
+penalty.allowed-ref-starts-with[0]=LATE_FILING
+penalty.allowed-ref-starts-with[1]=SANCTIONS
 penalty.ref-starts-with-path=/late-filing-penalty/ref-starts-with
 penalty.ref-starts-with-url=${chs.url}${penalty.ref-starts-with-path}
 penalty.enter-details-path=/late-filing-penalty/enter-details

--- a/src/main/resources/templates/pps/bankTransferPenaltyReference.html
+++ b/src/main/resources/templates/pps/bankTransferPenaltyReference.html
@@ -32,14 +32,15 @@
                         <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios" style="margin-bottom:1em;" th:each="penaltyReference : ${availablePenaltyReference}">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input piwik-event"
-                                       th:id="${penaltyReference}"
+                                       th:id="${penaltyReference.name}"
                                        name="available-penalty-reference"
                                        type="radio"
-                                       th:value="${penaltyReference}"
+                                       th:value="${penaltyReference.name}"
                                        th:field="*{selectedPenaltyReference}"
                                        th:errorclass="govuk-error-message"
-                                       th:attr="data-event-id=${penaltyReference}"/>
-                                <label class="govuk-label govuk-radios__label" th:for="${penaltyReference}" th:text="${penaltyReference}">keyvalue</label>
+                                       th:attr="data-event-id=${penaltyReference.name}"/>
+                                <label class="govuk-label govuk-radios__label" th:for="${penaltyReference}"
+                                       th:text="${penaltyReference.startsWith}">PenaltyReference.startsWith</label>
                             </div>
                         </div>
                     </fieldset>

--- a/src/main/resources/templates/pps/penaltyRefStartsWith.html
+++ b/src/main/resources/templates/pps/penaltyRefStartsWith.html
@@ -38,15 +38,15 @@
                              style="margin-bottom:1em;">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input piwik-event"
-                                       th:id="${penaltyReference}"
+                                       th:id="${penaltyReference.name}"
                                        name="available-penalty-reference"
                                        type="radio"
-                                       th:value="${penaltyReference}"
+                                       th:value="${penaltyReference.name}"
                                        th:field="*{selectedPenaltyReference}"
                                        th:errorclass="govuk-error-message"
-                                       th:attr="data-event-id=${penaltyReference}"/>
+                                       th:attr="data-event-id=${penaltyReference.name}"/>
                                 <label class="govuk-label govuk-radios__label" th:for="${penaltyReference}"
-                                       th:text="${penaltyReference}">keyvalue</label>
+                                       th:text="${penaltyReference.startsWith}">PenaltyReference.startsWith</label>
                             </div>
                         </div>
                     </fieldset>

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
 import static java.lang.Boolean.FALSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,18 +24,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class BankTransferPenaltyReferenceControllerTest {
 
     private MockMvc mockMvc;
@@ -74,45 +80,65 @@ class BankTransferPenaltyReferenceControllerTest {
 
         configurePreviousController();
 
-        this.mockMvc.perform(get(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath()))
+        MvcResult mvcResult = this.mockMvc.perform(get(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_BANK_TRANSFER_PENALTY_REFERENCE))
                 .andExpect(model().attributeExists(AVAILABLE_PENALTY_REF_ATTR))
-                .andExpect(model().attributeExists(PENALTY_REFERENCE_CHOICE_ATTR));
+                .andExpect(model().attributeExists(PENALTY_REFERENCE_CHOICE_ATTR))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post PPS Bank Transfer Which Penalty Reference - empty selection")
     void postRequestBankTransferPenaltyReferenceEmptySelected() throws Exception {
 
-        this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath()))
+        MvcResult mvcResult = this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_BANK_TRANSFER_PENALTY_REFERENCE))
                 .andExpect(model().attributeExists(AVAILABLE_PENALTY_REF_ATTR))
                 .andExpect(model().attributeHasFieldErrors(PENALTY_REFERENCE_CHOICE_ATTR))
-                .andExpect(model().attributeErrorCount(PENALTY_REFERENCE_CHOICE_ATTR, 1));
+                .andExpect(model().attributeErrorCount(PENALTY_REFERENCE_CHOICE_ATTR, 1))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post PPS Bank Transfer Which Penalty Reference - late filing selection")
     void postRequestBankTransferPenaltyReferenceLateFilingSelected() throws Exception {
-        this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath())
+        MvcResult mvcResult = this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath())
                         .param(SELECTED_PENALTY_REF_ATTR, LATE_FILING.name()))
                 .andExpect(model().errorCount(0))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:"
-                        + penaltyConfigurationProperties.getBankTransferLateFilingDetailsPath()));
+                        + penaltyConfigurationProperties.getBankTransferLateFilingDetailsPath()))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertTrue(modelAndView.getModel().isEmpty());
     }
 
     @Test
     @DisplayName("Post PPS Bank Transfer Which Penalty Reference - sanctions selection")
     void postRequestBankTransferPenaltyReferenceSanctionSelected() throws Exception {
-        this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath())
+        MvcResult mvcResult = this.mockMvc.perform(post(penaltyConfigurationProperties.getBankTransferWhichPenaltyPath())
                         .param(SELECTED_PENALTY_REF_ATTR, SANCTIONS.name()))
                 .andExpect(model().errorCount(0))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:"
-                        + penaltyConfigurationProperties.getBankTransferSanctionsPath()));
+                        + penaltyConfigurationProperties.getBankTransferSanctionsPath()))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertTrue(modelAndView.getModel().isEmpty());
     }
 
     private void configurePreviousController() {

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
@@ -1,8 +1,13 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,9 +15,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -20,12 +27,15 @@ class BankTransferSanctionsDetailsControllerTest {
 
     private MockMvc mockMvc;
 
+    @Mock
+    private FeatureFlagChecker mockFeatureFlagChecker;
+
     @InjectMocks
     private BankTransferSanctionsDetailsController controller;
 
     private static final String BANK_TRANSFER_SANCTIONS_DETAILS_PATH = "/late-filing-penalty/bank-transfer/sanctions-details";
-
     private static final String BANK_TRANSFER_SANCTIONS_DETAILS = "pps/bankTransferSanctionsDetails";
+    private static final String ERROR_VIEW = "error";
 
     @BeforeEach
     void setup() {
@@ -35,10 +45,25 @@ class BankTransferSanctionsDetailsControllerTest {
     @Test
     @DisplayName("Get Bank Transfer Sanctions Details - success path")
     void getRequestSuccess() throws Exception {
+        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(TRUE);
 
         this.mockMvc.perform(get(BANK_TRANSFER_SANCTIONS_DETAILS_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(BANK_TRANSFER_SANCTIONS_DETAILS));
+
+        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
+    }
+
+    @Test
+    @DisplayName("Get Bank Transfer Sanctions Details - error path")
+    void getRequestError() throws Exception {
+        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(FALSE);
+
+        this.mockMvc.perform(get(BANK_TRANSFER_SANCTIONS_DETAILS_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
+
+        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/EnterDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/EnterDetailsControllerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.Locale.UK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -36,7 +38,9 @@ import uk.gov.companieshouse.web.pps.models.EnterDetails;
 import uk.gov.companieshouse.web.pps.service.company.CompanyService;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.service.penaltypayment.PenaltyPaymentService;
+import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PPSTestUtility;
+import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 import uk.gov.companieshouse.web.pps.validation.EnterDetailsValidator;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +51,9 @@ class EnterDetailsControllerTest {
 
     @Mock
     private MessageSource mockMessageSource;
+
+    @Mock
+    private FeatureFlagChecker mockFeatureFlagChecker;
 
     @Mock
     private EnterDetailsValidator mockEnterDetailsValidator;
@@ -114,13 +121,17 @@ class EnterDetailsControllerTest {
 
         configurePreviousController();
 
+        PenaltyReference lateFilingPenaltyRef = LATE_FILING;
+        when(mockFeatureFlagChecker.isPenaltyRefEnabled(lateFilingPenaltyRef)).thenReturn(TRUE);
+
         this.mockMvc.perform(get(ENTER_DETAILS_PATH)
-                        .queryParam("ref-starts-with", LATE_FILING.name()))
+                        .queryParam("ref-starts-with", lateFilingPenaltyRef.name()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(ENTER_DETAILS_VIEW))
                 .andExpect(model().attributeExists(ENTER_DETAILS_MODEL_ATTR))
                 .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
 
+        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(lateFilingPenaltyRef);
         verifyNoInteractions(mockEnterDetailsValidator);
     }
 
@@ -130,13 +141,35 @@ class EnterDetailsControllerTest {
 
         configurePreviousController();
 
+        PenaltyReference sanctionPenaltyRef = SANCTIONS;
+        when(mockFeatureFlagChecker.isPenaltyRefEnabled(sanctionPenaltyRef)).thenReturn(TRUE);
+
         this.mockMvc.perform(get(ENTER_DETAILS_PATH)
-                        .queryParam("ref-starts-with", SANCTIONS.name()))
+                        .queryParam("ref-starts-with", sanctionPenaltyRef.name()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(ENTER_DETAILS_VIEW))
                 .andExpect(model().attributeExists(ENTER_DETAILS_MODEL_ATTR))
                 .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
 
+        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(sanctionPenaltyRef);
+        verifyNoInteractions(mockEnterDetailsValidator);
+    }
+
+    @Test
+    @DisplayName("Get Details - Sanction view error path when sanctions feature flag disabled")
+    void getEnterDetailsErrorWhenSanctionRefStartsWithRequestDisabled() throws Exception {
+
+        PenaltyReference sanctionPenaltyRef = SANCTIONS;
+        when(mockFeatureFlagChecker.isPenaltyRefEnabled(sanctionPenaltyRef)).thenReturn(FALSE);
+
+        this.mockMvc.perform(get(ENTER_DETAILS_PATH)
+                        .queryParam("ref-starts-with", sanctionPenaltyRef.name()))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
+                .andExpect(model().attributeDoesNotExist(ENTER_DETAILS_MODEL_ATTR))
+                .andExpect(view().name(ERROR_PAGE));
+
+        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(sanctionPenaltyRef);
         verifyNoInteractions(mockEnterDetailsValidator);
     }
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
 import static java.lang.Boolean.FALSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,7 +28,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
@@ -70,46 +75,67 @@ class PenaltyRefStartsWithControllerTest {
     @DisplayName("Get 'penaltyRefStartsWith' screen - success")
     void getPenaltyRefStartsWith() throws Exception {
         configurePreviousController();
-        mockMvc.perform(get(penaltyConfigurationProperties.getRefStartsWithPath()))
+
+        MvcResult mvcResult = mockMvc.perform(get(penaltyConfigurationProperties.getRefStartsWithPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_PENALTY_REF_STARTS_WITH_TEMPLATE_NAME))
                 .andExpect(model().attributeExists(AVAILABLE_PENALTY_REF_ATTR))
-                .andExpect(model().attributeExists(PENALTY_REFERENCE_CHOICE_ATTR));
+                .andExpect(model().attributeExists(PENALTY_REFERENCE_CHOICE_ATTR))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - error: none selected")
     void postPenaltyRefStartsWithWhenNoneSelected() throws Exception {
-        mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath()))
+        MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_PENALTY_REF_STARTS_WITH_TEMPLATE_NAME))
                 .andExpect(model().attributeExists(AVAILABLE_PENALTY_REF_ATTR))
                 .andExpect(model().attributeHasFieldErrors(PENALTY_REFERENCE_CHOICE_ATTR))
-                .andExpect(model().attributeErrorCount(PENALTY_REFERENCE_CHOICE_ATTR, 1));
+                .andExpect(model().attributeErrorCount(PENALTY_REFERENCE_CHOICE_ATTR, 1))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - success: late filing selected")
     void postPenaltyRefStartsWithWhenLateFilingSelected() throws Exception {
-        mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
+        MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
                         .param(SELECTED_PENALTY_REFERENCE, LATE_FILING.name()))
                 .andExpect(model().errorCount(0))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name(
                         "redirect:" + penaltyConfigurationProperties.getEnterDetailsPath()
-                                + "?ref-starts-with=LATE_FILING"));
+                                + "?ref-starts-with=LATE_FILING"))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertTrue(modelAndView.getModel().isEmpty());
     }
 
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - success: sanction selected")
     void postPenaltyRefStartsWithWhenSanctionSelected() throws Exception {
-        mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
+        MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
                         .param(SELECTED_PENALTY_REFERENCE, SANCTIONS.name()))
                 .andExpect(model().errorCount(0))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name(
                         "redirect:" + penaltyConfigurationProperties.getEnterDetailsPath()
-                                + "?ref-starts-with=SANCTIONS"));
+                                + "?ref-starts-with=SANCTIONS"))
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertTrue(modelAndView.getModel().isEmpty());
     }
 
     private void configurePreviousController() {

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/FeatureFlagCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/FeatureFlagCheckerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.web.pps.util;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
+
+class FeatureFlagCheckerTest {
+
+    @Test
+    void isPenaltyRefEnabledWhenSanctionsIsDisabled() {
+        FeatureFlagConfigurationProperties featureFlagConfigurationProperties = new FeatureFlagConfigurationProperties();
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), FALSE));
+        FeatureFlagChecker featureFlagChecker = new FeatureFlagChecker(featureFlagConfigurationProperties);
+
+        assertTrue(featureFlagChecker.isPenaltyRefEnabled(LATE_FILING));
+        assertFalse(featureFlagChecker.isPenaltyRefEnabled(SANCTIONS));
+    }
+
+    @Test
+    void isPenaltyRefEnabledWhenSanctionsIsEnabled() {
+        FeatureFlagConfigurationProperties featureFlagConfigurationProperties = new FeatureFlagConfigurationProperties();
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), TRUE));
+        FeatureFlagChecker featureFlagChecker = new FeatureFlagChecker(featureFlagConfigurationProperties);
+
+        assertTrue(featureFlagChecker.isPenaltyRefEnabled(LATE_FILING));
+        assertTrue(featureFlagChecker.isPenaltyRefEnabled(SANCTIONS));
+    }
+
+    @Test
+    void isPenaltyRefEnabled() {
+        FeatureFlagChecker featureFlagChecker = new FeatureFlagChecker(new FeatureFlagConfigurationProperties());
+
+        assertTrue(featureFlagChecker.isPenaltyRefEnabled(LATE_FILING));
+        assertTrue(featureFlagChecker.isPenaltyRefEnabled(SANCTIONS));
+    }
+
+}


### PR DESCRIPTION
[SAN-63](https://companieshouse.atlassian.net/browse/SAN-63) Add FeatureFlagChecker.isPenaltyRefEnabled to ensure that SANCTIONS is disabled by default in application.properties
* Env var: `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224=false`
* Add PENALTY_REFERENCE_CHOICE_ATTR model assertions to tests
* Update README Configuration - Env: `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224` Feature flag to enable Penalty Payment for Sanctions

[SAN-63]: https://companieshouse.atlassian.net/browse/SAN-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ