### PR TITLE
SAN-198 Redirect to late filing details when `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224=false` on 'penaltyRefStartsWith' screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
@@ -17,7 +17,6 @@ import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.controller.BaseController;
 import uk.gov.companieshouse.web.pps.models.PenaltyReferenceChoice;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
-import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
 
 @Controller
@@ -34,14 +33,10 @@ public class BankTransferPenaltyReferenceController extends BaseController {
 
     public BankTransferPenaltyReferenceController(
             NavigatorService navigatorService,
-            PenaltyConfigurationProperties penaltyConfigurationProperties,
-            FeatureFlagChecker featureFlagChecker) {
+            PenaltyConfigurationProperties penaltyConfigurationProperties) {
         this.navigatorService = navigatorService;
         this.penaltyConfigurationProperties = penaltyConfigurationProperties;
-        availablePenaltyReference = penaltyConfigurationProperties.getAllowedRefStartsWith()
-                .stream()
-                .filter(featureFlagChecker::isPenaltyRefEnabled)
-                .toList();
+        availablePenaltyReference = penaltyConfigurationProperties.getAllowedRefStartsWith();
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsController.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static java.lang.Boolean.FALSE;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.pps.annotation.PreviousController;
 import uk.gov.companieshouse.web.pps.controller.BaseController;
 import uk.gov.companieshouse.web.pps.session.SessionService;
-import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyUtils;
 
 @Controller
@@ -22,9 +18,6 @@ public class BankTransferSanctionsDetailsController extends BaseController {
     private static final String BANK_TRANSFER_SANCTIONS_DETAILS = "pps/bankTransferSanctionsDetails";
 
     private static final String USER_EMAIL = "userEmail";
-
-    @Autowired
-    private FeatureFlagChecker featureFlagChecker;
 
     @Autowired
     private PenaltyUtils penaltyUtils;
@@ -38,10 +31,6 @@ public class BankTransferSanctionsDetailsController extends BaseController {
 
     @GetMapping
     public String getBankTransferSanctionsDetails(Model model) {
-        if (FALSE.equals(featureFlagChecker.isPenaltyRefEnabled(SANCTIONS))) {
-            return ERROR_VIEW;
-        }
-
         String loginEmail = penaltyUtils.getLoginEmail(sessionService);
         if (loginEmail != null && !loginEmail.isEmpty()) {
             model.addAttribute(USER_EMAIL, loginEmail);
@@ -51,4 +40,5 @@ public class BankTransferSanctionsDetailsController extends BaseController {
         }
         return getTemplateName();
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
@@ -50,6 +50,11 @@ public class PenaltyRefStartsWithController extends BaseController {
 
     @GetMapping
     public String getPenaltyRefStartsWith(Model model) {
+        if (availablePenaltyReference.size() == 1) {
+            return REDIRECT_URL_PREFIX + penaltyConfigurationProperties.getEnterDetailsPath()
+                    + "?ref-starts-with=" + availablePenaltyReference.getFirst().name();
+        }
+
         model.addAttribute(AVAILABLE_PENALTY_REF_ATTR, availablePenaltyReference);
         model.addAttribute(PENALTY_REFERENCE_CHOICE_ATTR, new PenaltyReferenceChoice());
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
@@ -32,6 +32,7 @@ public class PenaltyRefStartsWithController extends BaseController {
     private final PenaltyConfigurationProperties penaltyConfigurationProperties;
     private final List<PenaltyReference> availablePenaltyReference;
 
+    @SuppressWarnings("java:S3958") // Stream pipeline is used; toList() is a terminal operation
     public PenaltyRefStartsWithController(NavigatorService navigatorService,
             PenaltyConfigurationProperties penaltyConfigurationProperties,
             FeatureFlagChecker featureFlagChecker) {

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static java.lang.Boolean.FALSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,7 +18,6 @@ import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,10 +30,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ModelAndView;
-import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
-import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -63,14 +59,9 @@ class BankTransferPenaltyReferenceControllerTest {
         penaltyConfigurationProperties.setBankTransferSanctionsPath(
                 "/late-filing-penalty/bank-transfer/sanctions-details");
 
-        FeatureFlagConfigurationProperties featureFlagConfigurationProperties = new FeatureFlagConfigurationProperties();
-        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), FALSE));
-        FeatureFlagChecker featureFlagChecker = new FeatureFlagChecker(featureFlagConfigurationProperties);
-
         BankTransferPenaltyReferenceController controller = new BankTransferPenaltyReferenceController(
                 mockNavigatorService,
-                penaltyConfigurationProperties,
-                featureFlagChecker);
+                penaltyConfigurationProperties);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -89,7 +80,7 @@ class BankTransferPenaltyReferenceControllerTest {
 
         ModelAndView modelAndView = mvcResult.getModelAndView();
         assertNotNull(modelAndView);
-        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
+        assertEquals(List.of(LATE_FILING, SANCTIONS), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
@@ -106,7 +97,7 @@ class BankTransferPenaltyReferenceControllerTest {
 
         ModelAndView modelAndView = mvcResult.getModelAndView();
         assertNotNull(modelAndView);
-        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
+        assertEquals(List.of(LATE_FILING, SANCTIONS), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
@@ -1,16 +1,12 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +21,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
-import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,9 +28,6 @@ import uk.gov.companieshouse.web.pps.util.PenaltyUtils;
 class BankTransferSanctionsDetailsControllerTest {
 
     private MockMvc mockMvc;
-
-    @Mock
-    private FeatureFlagChecker mockFeatureFlagChecker;
 
     @Mock
     private SessionService sessionService;
@@ -63,8 +55,6 @@ class BankTransferSanctionsDetailsControllerTest {
     @Test
     @DisplayName("Get Bank Transfer Sanctions Details - success path")
     void getRequestSuccess() throws Exception {
-        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(TRUE);
-
         configurePreviousController();
         configureMockEmailExist();
 
@@ -72,27 +62,11 @@ class BankTransferSanctionsDetailsControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name(BANK_TRANSFER_SANCTIONS_DETAILS))
                 .andExpect(model().attributeExists(USER_BAR_ATTR));
-
-        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
-    }
-
-    @Test
-    @DisplayName("Get Bank Transfer Sanctions Details - error path")
-    void getRequestError() throws Exception {
-        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(FALSE);
-
-        this.mockMvc.perform(get(BANK_TRANSFER_SANCTIONS_DETAILS_PATH))
-                .andExpect(status().isOk())
-                .andExpect(view().name(ERROR_VIEW));
-
-        verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
     }
 
     @Test
     @DisplayName("Get Bank Transfer Sanctions Details - success path without login")
     void getRequestSuccessWithoutLogin() throws Exception {
-        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(TRUE);
-
         configurePreviousController();
         configureMockEmailNotExist();
 
@@ -105,8 +79,6 @@ class BankTransferSanctionsDetailsControllerTest {
     @Test
     @DisplayName("Get Bank Transfer Sanctions Details - success path null email")
     void getRequestSuccessNullEmail() throws Exception {
-        when(mockFeatureFlagChecker.isPenaltyRefEnabled(SANCTIONS)).thenReturn(TRUE);
-
         configurePreviousController();
         configureMockEmailNull();
 
@@ -115,7 +87,6 @@ class BankTransferSanctionsDetailsControllerTest {
                 .andExpect(view().name(BANK_TRANSFER_SANCTIONS_DETAILS))
                 .andExpect(model().attributeDoesNotExist(USER_BAR_ATTR));
     }
-
 
     private void configurePreviousController() {
         when(mockNavigatorService.getPreviousControllerPath(any()))
@@ -133,4 +104,5 @@ class BankTransferSanctionsDetailsControllerTest {
     private void configureMockEmailNotExist() {
         when(mockPenaltyUtils.getLoginEmail(any())).thenReturn("");
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
 import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,6 +50,7 @@ class PenaltyRefStartsWithControllerTest {
     private NavigatorService mockNavigatorService;
 
     private PenaltyConfigurationProperties penaltyConfigurationProperties;
+    private FeatureFlagConfigurationProperties featureFlagConfigurationProperties;
 
     @BeforeEach
     void setup() {
@@ -60,8 +62,10 @@ class PenaltyRefStartsWithControllerTest {
         penaltyConfigurationProperties.setEnterDetailsPath(
                 "/late-filing-penalty/enter-details");
 
-        FeatureFlagConfigurationProperties featureFlagConfigurationProperties = new FeatureFlagConfigurationProperties();
-        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), FALSE));
+        featureFlagConfigurationProperties = new FeatureFlagConfigurationProperties();
+    }
+
+    void setupMockMvc() {
         FeatureFlagChecker featureFlagChecker = new FeatureFlagChecker(featureFlagConfigurationProperties);
 
         PenaltyRefStartsWithController controller = new PenaltyRefStartsWithController(
@@ -72,10 +76,27 @@ class PenaltyRefStartsWithControllerTest {
     }
 
     @Test
+    @DisplayName("Get 'penaltyRefStartsWith' screen - redirect late filing details")
+    void getPenaltyRefStartsWithSanctionsDisabled() throws Exception {
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), FALSE));
+        setupMockMvc();
+
+        MvcResult mvcResult = mockMvc.perform(get(penaltyConfigurationProperties.getRefStartsWithPath()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+        ModelAndView modelAndView = mvcResult.getModelAndView();
+        assertNotNull(modelAndView);
+        assertEquals("redirect:/late-filing-penalty/enter-details?ref-starts-with=LATE_FILING", modelAndView.getViewName());
+    }
+
+    @Test
     @DisplayName("Get 'penaltyRefStartsWith' screen - success")
-    void getPenaltyRefStartsWith() throws Exception {
+    void getPenaltyRefStartsWithSanctionsEnabled() throws Exception {
         configurePreviousController();
 
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), TRUE));
+        setupMockMvc();
         MvcResult mvcResult = mockMvc.perform(get(penaltyConfigurationProperties.getRefStartsWithPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_PENALTY_REF_STARTS_WITH_TEMPLATE_NAME))
@@ -85,12 +106,15 @@ class PenaltyRefStartsWithControllerTest {
 
         ModelAndView modelAndView = mvcResult.getModelAndView();
         assertNotNull(modelAndView);
-        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
+        assertEquals(List.of(LATE_FILING, SANCTIONS), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - error: none selected")
     void postPenaltyRefStartsWithWhenNoneSelected() throws Exception {
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), TRUE));
+        setupMockMvc();
+
         MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath()))
                 .andExpect(status().isOk())
                 .andExpect(view().name(PPS_PENALTY_REF_STARTS_WITH_TEMPLATE_NAME))
@@ -101,12 +125,15 @@ class PenaltyRefStartsWithControllerTest {
 
         ModelAndView modelAndView = mvcResult.getModelAndView();
         assertNotNull(modelAndView);
-        assertEquals(List.of(LATE_FILING), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
+        assertEquals(List.of(LATE_FILING, SANCTIONS), modelAndView.getModel().get(AVAILABLE_PENALTY_REF_ATTR));
     }
 
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - success: late filing selected")
     void postPenaltyRefStartsWithWhenLateFilingSelected() throws Exception {
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), TRUE));
+        setupMockMvc();
+
         MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
                         .param(SELECTED_PENALTY_REFERENCE, LATE_FILING.name()))
                 .andExpect(model().errorCount(0))
@@ -124,6 +151,9 @@ class PenaltyRefStartsWithControllerTest {
     @Test
     @DisplayName("Post 'penaltyRefStartsWith' screen - success: sanction selected")
     void postPenaltyRefStartsWithWhenSanctionSelected() throws Exception {
+        featureFlagConfigurationProperties.setPenaltyRefEnabled(Map.of(SANCTIONS.name(), TRUE));
+        setupMockMvc();
+
         MvcResult mvcResult = mockMvc.perform(post(penaltyConfigurationProperties.getRefStartsWithPath())
                         .param(SELECTED_PENALTY_REFERENCE, SANCTIONS.name()))
                 .andExpect(model().errorCount(0))


### PR DESCRIPTION
[SAN-198](https://companieshouse.atlassian.net/browse/SAN-198) Redirect to late filing details when `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224=false` on 'penaltyRefStartsWith' screen
* Pay by bank transfer shows both LATE_FILING, SANCTIONS
* Suppress SONARJAVA (java:S3958) - Intermediate Stream methods should not be left unused
We need to use the latest Java Rules since we are using Java 21.  It should already be fixed here to support Stream#toList() method introduced in JDK16 - SONARJAVA-3746: Extend rule S2201 to support 'Stream' non-void terminal methods

[SAN-198]: https://companieshouse.atlassian.net/browse/SAN-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ