### PR TITLE
SAN-201: Fix security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     </parent>
     <properties>
         <java.version>21</java.version>
-        <structured-logging.version>3.0.20</structured-logging.version>
+        <structured-logging.version>3.0.24</structured-logging.version>
         <log4j-bom.version>2.24.3</log4j-bom.version>
         <common-web-java.version>3.0.33</common-web-java.version>
-        <java-session-handler.version>4.1.3</java-session-handler.version>
-        <web-security-java.version>3.1.0</web-security-java.version>
+        <java-session-handler.version>4.1.4</java-session-handler.version>
+        <web-security-java.version>3.1.2</web-security-java.version>
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
@@ -67,6 +67,15 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+            <!-- transitive dependency issue with logback-core GHSA-pr98-23f8-jwxv -->
+            <!-- creates conflict with project's slf4j provider if updated as a dependency to 1.5.16
+            instead of excluding the library -->
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
                 </exclusion>
-
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <web-security-java.version>3.1.2</web-security-java.version>
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
-        <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
+        <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
         <api-sdk-java.version>6.0.23</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
@@ -103,6 +103,13 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>


### PR DESCRIPTION
Updated the libraries we use that have the logback-core dependency
- structured-logging
- java-session-handler
- web-security-java
All reviewed by other projects and committed and added new versions to the project.
Excluded 'logback-core' from 'spring-boot-starter-validation' as the latest version without the vulnerability '1.5.16' has breaking changes in it, it is not a true patch release (comment in ticket of issues). 