### PR TITLE
SAN-196 Matomo config - Pay another penalty * Also correct the "Start now" event / goal on the homepage

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,9 @@ enquiries=mailto:enquiries@companieshouse.gov.uk
 
 feature-flag.penalty-ref-enabled.SANCTIONS=${FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224:false}
 
+matomo.start-now-button-goal-id=${PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID}
+matomo.pay-another-penalty-goal-id=${PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID}
+
 penalty.allowed-ref-starts-with[0]=LATE_FILING
 penalty.allowed-ref-starts-with[1]=SANCTIONS
 penalty.ref-starts-with-path=/late-filing-penalty/ref-starts-with

--- a/src/main/resources/templates/pps/confirmationPage.html
+++ b/src/main/resources/templates/pps/confirmationPage.html
@@ -77,9 +77,13 @@
                     If you have another penalty to pay
                 </h2>
                 <p class="govuk-body">
-                    You can use this service again to <a id="penalty-ref-starts-with-link"
-                                                         th:href="${@environment.getProperty('penalty.ref-starts-with-url')}"
-                                                         class="govuk-link">pay another penalty</a>.
+                    You can use this service again to
+                    <a id="penalty-ref-starts-with-link"
+                       th:href="${@environment.getProperty('penalty.ref-starts-with-url')}"
+                       class="govuk-link"
+                       data-event-id="Pay another penalty link"
+                       th:onclick="_paq.push(['trackGoal', [[${@environment.getProperty('matomo.pay-another-penalty-goal-id')}]]]);">
+                    pay another penalty</a>.
                 </p>
                 <br><br>
                 <p class="govuk-body">

--- a/src/main/resources/templates/pps/home.html
+++ b/src/main/resources/templates/pps/home.html
@@ -48,8 +48,9 @@
                 <p class="govuk-body">It usually takes around 5 minutes to pay. We'll email you a receipt.</p>
 
                 <div class="form-group">
-                    <input id="next-button" class="govuk-button" data-event-id="lfp - Start now"
-                           onclick="_paq.push(['trackGoal', 3]);" type="submit" role="button" value="Start now"/>
+                    <input id="next-button" class="govuk-button" data-event-id="Pay a penalty - Start now"
+                           th:onclick="_paq.push(['trackGoal', [[${@environment.getProperty('matomo.start-now-button-goal-id')}]]]);"
+                           type="submit" role="button" value="Start now"/>
                 </div>
 
                 <p class="govuk-body">


### PR DESCRIPTION
[SAN-196](https://companieshouse.atlassian.net/browse/SAN-196) Matomo config - Pay another penalty
* Also correct the "Start now" event / goal on the homepage

Depends on https://github.com/companieshouse/ecs-service-configs-dev/pull/931

[SAN-196]: https://companieshouse.atlassian.net/browse/SAN-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ