### PR TITLE
SAN-262 update penalty summary page labels

### DIFF
--- a/src/main/resources/locales/messages.properties
+++ b/src/main/resources/locales/messages.properties
@@ -8,4 +8,10 @@ details.penalty-ref-hint.SANCTIONS=This starts with P, followed by 7 numbers. Fo
 details.penalty-notice-text.SANCTIONS=You'll find these numbers at the top of your penalty notice.
 details.penalty-details-not-found-error.SANCTIONS=The details you have entered do not match the information we hold. Enter the company number and penalty reference exactly as they are shown on your penalty notice.
 
-viewPenalties.penalty-ref-title=Penalty Reference
+viewPenalties.page-title=View your penalty
+viewPenalties.penalty-summary-title=Penalty summary
+viewPenalties.penalty-ref-label=Penalty reference
+viewPenalties.reason-for-penalty-label=Reason for penalty
+viewPenalties.company-number-label=Company number
+viewPenalties.issued-to-label=Issued to
+viewPenalties.amount-label=Amount

--- a/src/main/resources/templates/pps/viewPenalties.html
+++ b/src/main/resources/templates/pps/viewPenalties.html
@@ -5,8 +5,7 @@
       layout:decorate="~{layouts/baseLayout}">
 
 <head>
-    <title>
-        View your penalty
+    <title th:text="#{viewPenalties.page-title}">
     </title>
 </head>
 
@@ -16,32 +15,32 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <h1 id="page-title " class="govuk-heading-xl">
-                    <span id="page-title-heading">Penalty summary</span>
+                    <span id="page-title-heading" th:text="#{viewPenalties.penalty-summary-title}"></span>
                 </h1>
 
                 <table class="govuk-table" style="width: 800px">
                     <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__header" style="width:40%">Issued to</td>
+                        <td class="govuk-table__header" style="width:40%" th:text="#{viewPenalties.issued-to-label}"></td>
                         <td class="govuk-table__cell" th:text="${companyName}"></td>
                     </tr>
                     </thead>
 
                     <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__header">Company number</td>
+                        <td class="govuk-table__header" th:text="#{viewPenalties.company-number-label}"></td>
                         <td class="govuk-table__cell" th:text="${companyNumber}"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__header" th:text="#{viewPenalties.penalty-ref-title}"></td>
+                        <td class="govuk-table__header" th:text="#{viewPenalties.penalty-ref-label}"></td>
                         <td class="govuk-table__cell" th:text="${penaltyReference}"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__header">Reason for penalty</td>
+                        <td class="govuk-table__header" th:text="#{viewPenalties.reason-for-penalty-label}"></td>
                         <td class="govuk-table__cell" th:text="${reasonForPenalty}"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__header">Amount</td>
+                        <td class="govuk-table__header" th:text="#{viewPenalties.amount-label}"></td>
                         <td class="govuk-table__cell" th:text="'£' + ${outstanding} + ' (no VAT is charged)'"></td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
* Update penalty reference label in 'Penalty Summary' page to use similar text format as other labels
* Move label texts and title in 'Penalty Summary' to message properties