### PR TITLE
SAN-316-Sign-Out-Redirect-to-GDS updating signed out url

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
@@ -21,6 +21,7 @@ public class PenaltyConfigurationProperties {
     private String surveyLink;
     private String serviceBannerLink;
     private String startPath;
+    private String signedOutUrl;
 
     public List<PenaltyReference> getAllowedRefStartsWith() {
         return allowedRefStartsWith;
@@ -109,5 +110,13 @@ public class PenaltyConfigurationProperties {
 
     public void setStartPath(String startPath) {
         this.startPath = startPath;
+    }
+
+    public String getSignedOutUrl() {
+        return signedOutUrl;
+    }
+
+    public void setSignedOutUrl (String signedOutUrl) {
+        this.signedOutUrl = signedOutUrl;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutController.java
@@ -29,7 +29,6 @@ public class SignOutController extends BaseController {
 
     static final String SIGN_OUT_TEMPLATE_NAME = "pps/signOut";
     private static final String SIGN_IN_KEY = "signin_info";
-    private static final String ACCOUNT_URL = System.getenv("ACCOUNT_URL");
     private static final String SIGN_OUT_URL = "/late-filing-penalty/sign-out";
     private static final String HOME = "/late-filing-penalty/";
     private static final String BACK_LINK = "backLink";
@@ -91,7 +90,7 @@ public class SignOutController extends BaseController {
             return new RedirectView(SIGN_OUT_URL, true, false);
         }
         if (valueGet.equals("yes")) {
-            return new RedirectView(ACCOUNT_URL + "/signout");
+            return new RedirectView(penaltyConfigurationProperties.getSignedOutUrl() + "/signout");
         }
         if (valueGet.equals("no")) {
             return new RedirectView(url);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,7 @@ penalty.survey-link=https://www.smartsurvey.co.uk/s/pay-a-penalty-feedback
 penalty.service-banner-link=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
 penalty.unscheduled-service-down-path=/late-filing-penalty/unscheduled-service-down
 penalty.start-path=/late-filing-penalty
+penalty.signed-out-url=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
 
 penalty.bank-transfer-late-filing.account-name=${CH_BANK_ACC_NAME:Companies House}
 penalty.bank-transfer-late-filing.sort-code=${CH_BANK_SORT_CODE:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,10 +26,11 @@ penalty.bank-transfer-late-filing-details-path=/late-filing-penalty/bank-transfe
 penalty.bank-transfer-sanctions-path=/late-filing-penalty/bank-transfer/P
 penalty.sign-out-path=/late-filing-penalty/sign-out
 penalty.survey-link=https://www.smartsurvey.co.uk/s/pay-a-penalty-feedback
-penalty.service-banner-link=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
+penalty.service-banner-link=${penalty.gov-uk-pay-penalty-url}
 penalty.unscheduled-service-down-path=/late-filing-penalty/unscheduled-service-down
-penalty.start-path=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
-penalty.signed-out-url=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
+penalty.start-path=${penalty.gov-uk-pay-penalty-url}
+penalty.signed-out-url=${penalty.gov-uk-pay-penalty-url}
+penalty.gov-uk-pay-penalty-url=${GOV_UK_PAY_PENALTY_URL:https://www.gov.uk/pay-penalty-companies-house}
 
 penalty.bank-transfer-late-filing.account-name=${CH_BANK_ACC_NAME:Companies House}
 penalty.bank-transfer-late-filing.sort-code=${CH_BANK_SORT_CODE:}


### PR DESCRIPTION
For ticket: https://companieshouse.atlassian.net/browse/SAN-316

Updating where user is taken to whenever clicking "yes" and confirming sign out. For lower environments (CIDEV and Local) the user will be taken to the "Search the register" page and in live they should be taken to the GDS home page.