### PR TITLE
SAN-361 TIDY Code Style: Optimize Java imports in penalty-payment-web using editorconfig (ij_java_imports_layout)

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/config/FeatureFlagConfigurationProperties.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/FeatureFlagConfigurationProperties.java
@@ -1,10 +1,11 @@
 package uk.gov.companieshouse.web.pps.config;
 
-import static java.util.Collections.emptyMap;
-
-import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 @Configuration
 @ConfigurationProperties("feature-flag")

--- a/src/main/java/uk/gov/companieshouse/web/pps/config/MessageConfig.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/MessageConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.pps.config;
 
-import java.util.Locale;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +9,8 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+
+import java.util.Locale;
 
 @Configuration
 public class MessageConfig implements WebMvcConfigurer {

--- a/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/config/PenaltyConfigurationProperties.java
@@ -1,10 +1,11 @@
 package uk.gov.companieshouse.web.pps.config;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 @ConfigurationProperties("penalty")

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/BaseController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/BaseController.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller;
 
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -11,6 +10,8 @@ import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.PenaltyUtils;
+
+import java.util.Map;
 
 public abstract class BaseController {
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceController.java
@@ -1,9 +1,6 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -18,6 +15,10 @@ import uk.gov.companieshouse.web.pps.models.PenaltyReferenceChoice;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
+
+import java.util.List;
+
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 @Controller
 @RequestMapping("/late-filing-penalty/bank-transfer")

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyPaidController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyPaidController.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,6 +14,8 @@ import uk.gov.companieshouse.web.pps.service.company.CompanyService;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.PenaltyUtils;
+
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 @Controller
 @RequestMapping("/late-filing-penalty/company/{companyNumber}/penalty/{penaltyRef}/penalty-paid")

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithController.java
@@ -1,9 +1,6 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -19,6 +16,10 @@ import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
+
+import java.util.List;
+
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 @Controller
 @RequestMapping("/late-filing-penalty/ref-starts-with")

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutController.java
@@ -1,9 +1,6 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -18,6 +15,10 @@ import uk.gov.companieshouse.web.pps.controller.BaseController;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.validation.AllowlistChecker;
+
+import java.util.Map;
+
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 
 @Controller

--- a/src/main/java/uk/gov/companieshouse/web/pps/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.web.pps.exception;
 
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -11,6 +9,8 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.pps.PPSWebApplication;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
+
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/uk/gov/companieshouse/web/pps/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/interceptor/LoggingInterceptor.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.web.pps.interceptor;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
@@ -7,9 +9,6 @@ import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.logging.util.RequestLogger;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 import static uk.gov.companieshouse.web.pps.PPSWebApplication.APPLICATION_NAME_SPACE;
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/interceptor/UserDetailsInterceptor.java
@@ -2,14 +2,15 @@ package uk.gov.companieshouse.web.pps.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
-import java.util.Optional;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.Map;
+import java.util.Optional;
 
 @Component
 public class UserDetailsInterceptor implements AsyncHandlerInterceptor {

--- a/src/main/java/uk/gov/companieshouse/web/pps/util/FeatureFlagChecker.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/util/FeatureFlagChecker.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.web.pps.util;
 
-import static java.lang.Boolean.TRUE;
-
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
+
+import static java.lang.Boolean.TRUE;
 
 @Component
 public class FeatureFlagChecker {

--- a/src/main/java/uk/gov/companieshouse/web/pps/util/PenaltyUtils.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/util/PenaltyUtils.java
@@ -1,11 +1,12 @@
 package uk.gov.companieshouse.web.pps.util;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 
 public final class PenaltyUtils {
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/validation/AllowlistChecker.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/validation/AllowlistChecker.java
@@ -5,8 +5,8 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.pps.PPSWebApplication;
 
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 public class AllowlistChecker {

--- a/src/main/java/uk/gov/companieshouse/web/pps/validation/EnterDetailsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/validation/EnterDetailsValidator.java
@@ -1,13 +1,14 @@
 package uk.gov.companieshouse.web.pps.validation;
 
-import static java.util.Locale.UK;
-import static java.util.ResourceBundle.getBundle;
-
-import java.util.ResourceBundle;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import uk.gov.companieshouse.web.pps.models.EnterDetails;
 import uk.gov.companieshouse.web.pps.util.PenaltyReference;
+
+import java.util.ResourceBundle;
+
+import static java.util.Locale.UK;
+import static java.util.ResourceBundle.getBundle;
 
 @Component
 public class EnterDetailsValidator {

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferLateFilingDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferLateFilingDetailsControllerTest.java
@@ -1,15 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferLateFilingDetailsController.BANK_TRANSFER_LATE_FILING_DETAILS_TEMPLATE_NAME;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +12,17 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferLateFilingDetailsController.BANK_TRANSFER_LATE_FILING_DETAILS_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferPenaltyReferenceControllerTest.java
@@ -1,20 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.AVAILABLE_PENALTY_REF_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.BANK_TRANSFER_PENALTY_REFERENCE_TEMPLATE_NAME;
-import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.PENALTY_REFERENCE_CHOICE_ATTR;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
-
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +15,22 @@ import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.AVAILABLE_PENALTY_REF_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.BANK_TRANSFER_PENALTY_REFERENCE_TEMPLATE_NAME;
+import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferPenaltyReferenceController.PENALTY_REFERENCE_CHOICE_ATTR;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/BankTransferSanctionsDetailsControllerTest.java
@@ -1,15 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferSanctionsDetailsController.BANK_TRANSFER_SANCTIONS_DETAILS_TEMPLATE_NAME;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +12,17 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.BankTransferSanctionsDetailsController.BANK_TRANSFER_SANCTIONS_DETAILS_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/OnlinePaymentUnavailableControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/OnlinePaymentUnavailableControllerTest.java
@@ -1,11 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.pps.OnlinePaymentUnavailableController.ONLINE_PAYMENT_UNAVAILABLE_TEMPLATE_NAME;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +12,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.pps.OnlinePaymentUnavailableController.ONLINE_PAYMENT_UNAVAILABLE_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyPaidControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyPaidControllerTest.java
@@ -1,16 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyPaidController.PENALTY_PAID_TEMPLATE_NAME;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +15,17 @@ import uk.gov.companieshouse.web.pps.service.company.CompanyService;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.PPSTestUtility;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
+import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyPaidController.PENALTY_PAID_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/PenaltyRefStartsWithControllerTest.java
@@ -1,23 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.AVAILABLE_PENALTY_REF_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.PENALTY_REFERENCE_CHOICE_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.PENALTY_REF_STARTS_WITH_TEMPLATE_NAME;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
-
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +17,25 @@ import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.util.FeatureFlagChecker;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.AVAILABLE_PENALTY_REF_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.PENALTY_REFERENCE_CHOICE_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.PenaltyRefStartsWithController.PENALTY_REF_STARTS_WITH_TEMPLATE_NAME;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/SignOutControllerTest.java
@@ -1,18 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-import static uk.gov.companieshouse.web.pps.controller.pps.SignOutController.SIGN_OUT_TEMPLATE_NAME;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +13,20 @@ import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
 import uk.gov.companieshouse.web.pps.validation.AllowlistChecker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
+import static uk.gov.companieshouse.web.pps.controller.pps.SignOutController.SIGN_OUT_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/UnscheduledServiceDownControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/UnscheduledServiceDownControllerTest.java
@@ -1,14 +1,5 @@
 package uk.gov.companieshouse.web.pps.controller.pps;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
-import static uk.gov.companieshouse.web.pps.controller.pps.UnscheduledServiceDownController.UNSCHEDULED_SERVICE_DOWN_TEMPLATE_NAME;
-
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +12,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.companieshouse.web.pps.controller.BaseController.USER_BAR_ATTR;
+import static uk.gov.companieshouse.web.pps.controller.pps.UnscheduledServiceDownController.UNSCHEDULED_SERVICE_DOWN_TEMPLATE_NAME;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/exception/GlobalExceptionHandlerTest.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.web.pps.exception;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
-
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +8,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/interceptor/LoggingInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/interceptor/LoggingInterceptorTests.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.web.pps.interceptor;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,9 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.logging.util.LogContextProperties;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/interceptor/UserDetailsInterceptorTests.java
@@ -1,16 +1,7 @@
 package uk.gov.companieshouse.web.pps.interceptor;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +11,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserDetailsInterceptorTests {

--- a/src/test/java/uk/gov/companieshouse/web/pps/security/WebSecurityTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/security/WebSecurityTests.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.web.pps.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +11,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SystemStubsExtension.class)
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/company/impl/CompanyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/company/impl/CompanyServiceImplTest.java
@@ -1,9 +1,5 @@
 package uk.gov.companieshouse.web.pps.service.company.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +17,10 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.pps.api.ApiClientService;
 import uk.gov.companieshouse.web.pps.exception.ServiceException;
 import uk.gov.companieshouse.web.pps.service.company.CompanyService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/navigation/NavigatorServiceTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/navigation/NavigatorServiceTests.java
@@ -1,9 +1,5 @@
 package uk.gov.companieshouse.web.pps.service.navigation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +24,10 @@ import uk.gov.companieshouse.web.pps.service.navigation.success.MockSuccessJourn
 import uk.gov.companieshouse.web.pps.service.navigation.success.MockSuccessJourneyControllerThree;
 import uk.gov.companieshouse.web.pps.service.navigation.success.MockSuccessJourneyControllerTwo;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/FeatureFlagCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/FeatureFlagCheckerTest.java
@@ -1,15 +1,16 @@
 package uk.gov.companieshouse.web.pps.util;
 
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
+
+import java.util.Map;
+
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
-
-import java.util.Map;
-import org.junit.jupiter.api.Test;
-import uk.gov.companieshouse.web.pps.config.FeatureFlagConfigurationProperties;
 
 class FeatureFlagCheckerTest {
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/PenaltyReferenceTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/PenaltyReferenceTest.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.web.pps.util;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 import static uk.gov.companieshouse.web.pps.util.PenaltyReference.fromStartsWith;
-
-import org.junit.jupiter.api.Test;
 
 class PenaltyReferenceTest {
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/PenaltyUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/PenaltyUtilsTest.java
@@ -1,14 +1,15 @@
 package uk.gov.companieshouse.web.pps.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
-
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.web.pps.config.PenaltyConfigurationProperties;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
 
 class PenaltyUtilsTest {
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/validation/EnterDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/validation/EnterDetailsValidatorTest.java
@@ -1,17 +1,18 @@
 package uk.gov.companieshouse.web.pps.validation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
-import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
-
-import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import uk.gov.companieshouse.web.pps.models.EnterDetails;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.LATE_FILING;
+import static uk.gov.companieshouse.web.pps.util.PenaltyReference.SANCTIONS;
 
 class EnterDetailsValidatorTest {
 


### PR DESCRIPTION
[SAN-361](https://companieshouse.atlassian.net/browse/SAN-361) TIDY Code Style: Optimize Java imports in penalty-payment-web using editorconfig (ij_java_imports_layout)

See [IntelliJ Setup](https://companieshouse.atlassian.net/wiki/spaces/SANV/pages/4959010866/IntelliJ+Setup) 

`ij_java_imports_layout = *,|,java.**,javax.**,|,$*,|`

[SAN-361]: https://companieshouse.atlassian.net/browse/SAN-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ