### PR TITLE
SAN-66 Replace /financial-penalties with /penalties path due to AWS LB listener rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
         <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
-        <api-sdk-java.version>6.2.0</api-sdk-java.version>
+        <api-sdk-java.version>6.2.3</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
         <spring-boot-dependencies.version>3.4.3</spring-boot-dependencies.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
         <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
-        <api-sdk-java.version>6.1.0</api-sdk-java.version>
+        <api-sdk-java.version>6.2.0</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
         <spring-boot-dependencies.version>3.4.3</spring-boot-dependencies.version>

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImpl.java
@@ -20,10 +20,10 @@ import java.util.Collections;
 public class PayablePenaltyServiceImpl implements PayablePenaltyService {
 
     private static final UriTemplate GET_PAYABLE_URI =
-            new UriTemplate("/company/{companyNumber}/financial-penalties/payable/{payableRef}");
+            new UriTemplate("/company/{companyNumber}/penalties/payable/{payableRef}");
 
     private static final UriTemplate POST_PAYABLE_URI =
-            new UriTemplate("/company/{companyNumber}/financial-penalties/payable");
+            new UriTemplate("/company/{companyNumber}/penalties/payable");
 
     private final ApiClientService apiClientService;
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImpl.java
@@ -20,10 +20,10 @@ import java.util.Collections;
 public class PayablePenaltyServiceImpl implements PayablePenaltyService {
 
     private static final UriTemplate GET_PAYABLE_URI =
-            new UriTemplate("/company/{companyNumber}/penalties/late-filing/payable/{payableRef}");
+            new UriTemplate("/company/{companyNumber}/financial-penalties/payable/{payableRef}");
 
     private static final UriTemplate POST_PAYABLE_URI =
-            new UriTemplate("/company/{companyNumber}/penalties/late-filing/payable");
+            new UriTemplate("/company/{companyNumber}/financial-penalties/payable");
 
     private final ApiClientService apiClientService;
 

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class PenaltyPaymentServiceImpl implements PenaltyPaymentService {
 
     private static final UriTemplate GET_FINANCIAL_PENALTIES_URI =
-            new UriTemplate("/company/{companyNumber}/financial-penalties/{penaltyReferenceType}");
+            new UriTemplate("/company/{companyNumber}/penalties/{penaltyReferenceType}");
 
     private static final UriTemplate FINANCE_HEALTHCHECK_URI =
             new UriTemplate("/penalty-payment-api/healthcheck/finance-system");

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class PenaltyPaymentServiceImpl implements PenaltyPaymentService {
 
     private static final UriTemplate GET_FINANCIAL_PENALTIES_URI =
-            new UriTemplate("/company/{companyNumber}/penalties/late-filing/{penaltyReferenceType}");
+            new UriTemplate("/company/{companyNumber}/financial-penalties/{penaltyReferenceType}");
 
     private static final UriTemplate FINANCE_HEALTHCHECK_URI =
             new UriTemplate("/penalty-payment-api/healthcheck/finance-system");

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImplTest.java
@@ -64,9 +64,9 @@ class PayablePenaltyServiceImplTest {
 
     private static final Integer AMOUNT = 750;
 
-    private static final String POST_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/financial-penalties/payable";
+    private static final String POST_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/penalties/payable";
 
-    private static final String GET_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/financial-penalties/payable/" + PAYABLE_REF;
+    private static final String GET_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/penalties/payable/" + PAYABLE_REF;
 
     @BeforeEach
     void init() {

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PayablePenaltyServiceImplTest.java
@@ -64,9 +64,9 @@ class PayablePenaltyServiceImplTest {
 
     private static final Integer AMOUNT = 750;
 
-    private static final String POST_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/penalties/late-filing/payable";
+    private static final String POST_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/financial-penalties/payable";
 
-    private static final String GET_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/penalties/late-filing/payable/" + PAYABLE_REF;
+    private static final String GET_PAYABLE_URI = "/company/" + COMPANY_NUMBER + "/financial-penalties/payable/" + PAYABLE_REF;
 
     @BeforeEach
     void init() {

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
@@ -70,7 +70,7 @@ class PenaltyPaymentServiceImplTest {
     private static final String PENALTY_REF_TWO = "A0000001";
 
     private static final String GET_FINANCIAL_PENALTIES_LATE_FILING_URI =
-            "/company/" + COMPANY_NUMBER + "/penalties/late-filing/" + PenaltyReference.LATE_FILING;
+            "/company/" + COMPANY_NUMBER + "/financial-penalties/" + PenaltyReference.LATE_FILING;
 
     private static final String GET_FINANCE_HEALTHCHECK_URI = "/penalty-payment-api/healthcheck/finance-system";
 
@@ -161,7 +161,7 @@ class PenaltyPaymentServiceImplTest {
             throws ServiceException, ApiErrorResponseException, URIValidationException {
         when(apiClient.financialPenalty()).thenReturn(financialPenaltyResourceHandler);
 
-        String uri = "/company/" + COMPANY_NUMBER + "/penalties/late-filing/" + PenaltyReference.LATE_FILING;
+        String uri = "/company/" + COMPANY_NUMBER + "/financial-penalties/" + PenaltyReference.LATE_FILING;
         FinancialPenalty paidFinancialPenalty = PPSTestUtility.paidFinancialPenalty(
                 PENALTY_REF);
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
@@ -70,7 +70,7 @@ class PenaltyPaymentServiceImplTest {
     private static final String PENALTY_REF_TWO = "A0000001";
 
     private static final String GET_FINANCIAL_PENALTIES_LATE_FILING_URI =
-            "/company/" + COMPANY_NUMBER + "/financial-penalties/" + PenaltyReference.LATE_FILING;
+            "/company/" + COMPANY_NUMBER + "/penalties/" + PenaltyReference.LATE_FILING;
 
     private static final String GET_FINANCE_HEALTHCHECK_URI = "/penalty-payment-api/healthcheck/finance-system";
 
@@ -161,7 +161,7 @@ class PenaltyPaymentServiceImplTest {
             throws ServiceException, ApiErrorResponseException, URIValidationException {
         when(apiClient.financialPenalty()).thenReturn(financialPenaltyResourceHandler);
 
-        String uri = "/company/" + COMPANY_NUMBER + "/financial-penalties/" + PenaltyReference.LATE_FILING;
+        String uri = "/company/" + COMPANY_NUMBER + "/penalties/" + PenaltyReference.LATE_FILING;
         FinancialPenalty paidFinancialPenalty = PPSTestUtility.paidFinancialPenalty(
                 PENALTY_REF);
 

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/PPSTestUtility.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/PPSTestUtility.java
@@ -154,7 +154,7 @@ public class PPSTestUtility {
         PayableFinancialPenaltySession payableFinancialPenaltySession = new PayableFinancialPenaltySession();
         Map<String, String> links = new HashMap<>() {{
             put("self",
-                    "/company/" + companyNumber + "/penalties/late-filing/payable/" + PAYABLE_ID);
+                    "/company/" + companyNumber + "/financial-penalties/payable/" + PAYABLE_ID);
         }};
 
         payableFinancialPenaltySession.setId(PAYABLE_ID);

--- a/src/test/java/uk/gov/companieshouse/web/pps/util/PPSTestUtility.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/util/PPSTestUtility.java
@@ -153,8 +153,7 @@ public class PPSTestUtility {
     public static PayableFinancialPenaltySession payableFinancialPenaltySession(String companyNumber) {
         PayableFinancialPenaltySession payableFinancialPenaltySession = new PayableFinancialPenaltySession();
         Map<String, String> links = new HashMap<>() {{
-            put("self",
-                    "/company/" + companyNumber + "/financial-penalties/payable/" + PAYABLE_ID);
+            put("self", "/company/" + companyNumber + "/penalties/payable/" + PAYABLE_ID);
         }};
 
         payableFinancialPenaltySession.setId(PAYABLE_ID);


### PR DESCRIPTION
[SAN-66](https://companieshouse.atlassian.net/browse/SAN-66) Replace `/financial-penalties` with `/penalties` path due to AWS LB listener rule

[SAN-66]: https://companieshouse.atlassian.net/browse/SAN-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ