### PR TITLE
SAN-299-Matomo-STOP-screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,33 @@ In order to run this Web App locally you will need to install:
 
 ### Configuration
 
- Key                                                                | Description                                                         
---------------------------------------------------------------------|---------------------------------------------------------------------
- `PPS_PAY_WEB_PORT`                                                 | The port of the penalty-payment-web application                     
- `HUMAN_LOG`                                                        | For human readable logs                                             
- `CH_BANK_ACC_NAME`                                                 | Bacs payments - Account name (late filing penalty: A)               
- `CH_BANK_SORT_CODE`                                                | Bacs payments - Sort code (late filing penalty: A)                  
- `CH_BANK_ACC_NUM`                                                  | Bacs payments - Account number (late filing penalty: A)             
- `CH_BANK_IBAN`                                                     | Overseas payments - IBAN (late filing penalty: A)                   
- `CH_BANK_SWIFT_CODE`                                               | Overseas payments - SWIFT code (late filing penalty: A)             
- `CH_SANCTIONS_BANK_ACC_NAME`                                       | Bacs payments - Account name (sanction: P)                          
- `CH_SANCTIONS_BANK_SORT_CODE`                                      | Bacs payments - Sort code (sanction: P)                             
- `CH_SANCTIONS_BANK_ACC_NUM`                                        | Bacs payments - Account number (sanction: P)                        
- `CH_SANCTIONS_BANK_IBAN`                                           | Overseas payments - IBAN (sanction: P)                              
- `CH_SANCTIONS_BANK_SWIFT_CODE`                                     | Overseas payments - SWIFT code (sanction: P)                        
- `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224`                | Feature flag to enable Penalty Payment for Sanctions                
- `PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID`                  | Matomo Goal Id: PAY A PENALTY - Start Now Button                    
- `PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID`               | Matomo Goal Id: PAY A PENALTY - Pay another penalty                 
- `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_LFP_GOAL_ID`       | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with LFP A       
- `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_SANCTIONS_GOAL_ID` | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with Sanctions P 
- `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_LFP_GOAL_ID`      | Matomo Goal Id: PAY A PENALTY - Penalty details continue button A
- `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_SANCTIONS_GOAL_ID`| Matomo Goal Id: PAY A PENALTY - Penalty details continue button P
- `PENALTY_PAYMENT_MATOMO_PENALTY_IN_DCA_STOP_SCREEN_GOAL_ID`        | Matomo Goal Id: PAY A PENALTY - Penalty in DCA Stop Screen
- `GOV_UK_PAY_PENALTY_URL`                                           | GOV.UK service banner URL: Pay a penalty to Companies House
+ Key                                                                                | Description                                                         
+------------------------------------------------------------------------------------|----------------------------------------------------------------------------------
+ `PPS_PAY_WEB_PORT`                                                                 | The port of the penalty-payment-web application                     
+ `HUMAN_LOG`                                                                        | For human readable logs                                             
+ `CH_BANK_ACC_NAME`                                                                 | Bacs payments - Account name (late filing penalty: A)               
+ `CH_BANK_SORT_CODE`                                                                | Bacs payments - Sort code (late filing penalty: A)                  
+ `CH_BANK_ACC_NUM`                                                                  | Bacs payments - Account number (late filing penalty: A)             
+ `CH_BANK_IBAN`                                                                     | Overseas payments - IBAN (late filing penalty: A)                   
+ `CH_BANK_SWIFT_CODE`                                                               | Overseas payments - SWIFT code (late filing penalty: A)             
+ `CH_SANCTIONS_BANK_ACC_NAME`                                                       | Bacs payments - Account name (sanction: P)                          
+ `CH_SANCTIONS_BANK_SORT_CODE`                                                      | Bacs payments - Sort code (sanction: P)                             
+ `CH_SANCTIONS_BANK_ACC_NUM`                                                        | Bacs payments - Account number (sanction: P)                        
+ `CH_SANCTIONS_BANK_IBAN`                                                           | Overseas payments - IBAN (sanction: P)                              
+ `CH_SANCTIONS_BANK_SWIFT_CODE`                                                     | Overseas payments - SWIFT code (sanction: P)                        
+ `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224`                                | Feature flag to enable Penalty Payment for Sanctions                
+ `PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID`                                  | Matomo Goal Id: PAY A PENALTY - Start Now Button                    
+ `PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID`                               | Matomo Goal Id: PAY A PENALTY - Pay another penalty                 
+ `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_LFP_GOAL_ID`                       | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with LFP A       
+ `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_SANCTIONS_GOAL_ID`                 | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with Sanctions P 
+ `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_LFP_GOAL_ID`                      | Matomo Goal Id: PAY A PENALTY - Penalty details continue button A
+ `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_SANCTIONS_GOAL_ID`                | Matomo Goal Id: PAY A PENALTY - Penalty details continue button P
+ `PENALTY_PAYMENT_MATOMO_PENALTY_IN_DCA_STOP_SCREEN_GOAL_ID`                        | Matomo Goal Id: PAY A PENALTY - Penalty in DCA Stop Screen
+ `PENALTY_PAYMENT_MATOMO_UNSCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`              | Matomo Goal Id: PAY A PENALTY - Unscheduled Service Down Stop Screen
+ `PENALTY_PAYMENT_MATOMO_SCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`                | Matomo Goal Id: PAY A PENALTY - Scheduled Service Down Stop Screen
+ `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_LFP_STOP_SCREEN_GOAL_ID`        | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable LFP Stop Screen
+ `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_SANCTIONS_STOP_SCREEN_GOAL_ID`  | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable Sanctions Stop Screen
+ `GOV_UK_PAY_PENALTY_URL`                                                           | GOV.UK service banner URL: Pay a penalty to Companies House
 
 ### Web Pages
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,10 @@ matomo.penalty-ref-starts-with-sanctions-goal-id=${PENALTY_PAYMENT_MATOMO_PENALT
 matomo.penalty-details-continue-lfp-goal-id=${PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_LFP_GOAL_ID}
 matomo.penalty-details-continue-sanctions-goal-id=${PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_SANCTIONS_GOAL_ID}
 matomo.penalty-in-dca-stop-screen-goal-id=${PENALTY_PAYMENT_MATOMO_PENALTY_IN_DCA_STOP_SCREEN_GOAL_ID}
+matomo.unscheduled-service-down-stop-screen-goal-id=${PENALTY_PAYMENT_MATOMO_UNSCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID}
+matomo.scheduled-service-down-stop-screen-goal-id=${PENALTY_PAYMENT_MATOMO_SCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID}
+matomo.online-payment-unavailable-stop-screen-lfp-goal-id=${PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_LFP_STOP_SCREEN_GOAL_ID}
+matomo.online-payment-unavailable-stop-screen-sanctions-goal-id=${PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_SANCTIONS_STOP_SCREEN_GOAL_ID}
 
 penalty.allowed-ref-starts-with[0]=LATE_FILING
 penalty.allowed-ref-starts-with[1]=SANCTIONS

--- a/src/main/resources/templates/pps/onlinePaymentUnavailable.html
+++ b/src/main/resources/templates/pps/onlinePaymentUnavailable.html
@@ -8,6 +8,28 @@
     <title>
         You need to pay by bank transfer - Pay a penalty to Companies House - GOV.UK
     </title>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            var penaltyReference = '[[${penaltyReference}]]';
+            console.log("penaltyReference: ", penaltyReference);
+
+            if (penaltyReference === 'LATE_FILING') {
+                var goalId = document.getElementById('online-payment-unavailable-stop-screen-lfp-goal-id').value;
+                if (goalId) {
+                    if (window._paq) {
+                        _paq.push(['trackGoal', goalId]);
+                    }
+                }
+            } else if (penaltyReference === 'SANCTIONS') {
+                var goalId = document.getElementById('online-payment-unavailable-stop-screen-sanctions-goal-id').value;
+                if (goalId) {
+                    if (window._paq) {
+                        _paq.push(['trackGoal', goalId]);
+                    }
+                }
+            }
+        });
+    </script>
 </head>
 
 <div id="online-payment-unavailable-main-content" layout:fragment="content">
@@ -97,6 +119,10 @@
                     <a href="https://www.gov.uk/contact-companies-house" class="govuk-link">contact us</a>.</p>
             </div>
         </div>
+        <input type="hidden" th:value="${@environment.getProperty('matomo.online-payment-unavailable-stop-screen-lfp-goal-id')}"
+               id="online-payment-unavailable-stop-screen-lfp-goal-id">
+        <input type="hidden" th:value="${@environment.getProperty('matomo.online-payment-unavailable-stop-screen-sanctions-goal-id')}"
+               id="online-payment-unavailable-stop-screen-sanctions-goal-id">
     </form>
 </div>
 </html>

--- a/src/main/resources/templates/pps/onlinePaymentUnavailable.html
+++ b/src/main/resources/templates/pps/onlinePaymentUnavailable.html
@@ -11,7 +11,6 @@
     <script>
         document.addEventListener("DOMContentLoaded", function() {
             var penaltyReference = '[[${penaltyReference}]]';
-            console.log("penaltyReference: ", penaltyReference);
 
             if (penaltyReference === 'LATE_FILING') {
                 var goalId = document.getElementById('online-payment-unavailable-stop-screen-lfp-goal-id').value;

--- a/src/main/resources/templates/pps/serviceUnavailable.html
+++ b/src/main/resources/templates/pps/serviceUnavailable.html
@@ -6,6 +6,16 @@
 
 <head>
     <title>This service is unavailable - Pay a penalty to Companies House - GOV.UK</title>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+          var goalId = document.getElementById('scheduled-service-down-stop-screen-goal-id').value;
+
+          if (goalId) {
+            window._paq = window._paq || [];
+            _paq.push(['trackGoal', goalId]);
+          }
+        });
+    </script>
 </head>
 
 <div id="service-unavailable-main-content" layout:fragment="content">
@@ -161,6 +171,8 @@
                 </p>
             </div>
         </div>
+        <input type="hidden" th:value="${@environment.getProperty('matomo.scheduled-service-down-stop-screen-goal-id')}"
+               id="scheduled-service-down-stop-screen-goal-id">
     </form>
 </div>
 </html>

--- a/src/main/resources/templates/pps/unscheduledServiceDown.html
+++ b/src/main/resources/templates/pps/unscheduledServiceDown.html
@@ -8,6 +8,16 @@
   <title>
     This service is unavailable - Pay a penalty to Companies House - GOV.UK
   </title>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      var goalId = document.getElementById('unscheduled-service-down-stop-screen-goal-id').value;
+
+      if (goalId) {
+        window._paq = window._paq || [];
+        _paq.push(['trackGoal', goalId]);
+      }
+    });
+  </script>
 </head>
 
 <div id="unscheduled-service-down-main-content" layout:fragment="content">
@@ -154,6 +164,8 @@
           <a href="https://www.gov.uk/contact-companies-house" class="govuk-link">contact us</a>.</p>
       </div>
     </div>
+    <input type="hidden" th:value="${@environment.getProperty('matomo.unscheduled-service-down-stop-screen-goal-id')}"
+           id="unscheduled-service-down-stop-screen-goal-id">
   </form>
 </div>
 </html>


### PR DESCRIPTION
Adding in matomo tracking for stop screens, https://companieshouse.atlassian.net/browse/SAN-299

Linked to:
https://github.com/companieshouse/docker-chs-development/pull/1675
https://github.com/companieshouse/ecs-service-configs-dev/pull/1120
