### PR TITLE
SAN-391: Upgrade spring-boot to latest version to fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <api-sdk-java.version>6.2.6</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.4.3</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.3</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.4</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.4</spring-boot-maven-plugin.version>
 
         <json.version>20241224</json.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>


### PR DESCRIPTION
Upgrade spring-boot to latest version to fix security issue
spring-security-core-6.4.3.jar: CVE-2025-22223(6.9)