### PR TITLE
SAN-419 Update WebSecurity to remove old bankTransferSecurityFilterChain following recent removal of the bank-transfer pages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/PPSWebApplication.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/PPSWebApplication.java
@@ -33,7 +33,6 @@ public class PPSWebApplication implements WebMvcConfigurer {
                         "/late-filing-penalty",
                         "/pay-penalty",
                         "/pay-penalty/ref-starts-with",
-                        "/pay-penalty/bank-transfer/**",
                         "/pay-penalty/unscheduled-service-down"
                 );
     }

--- a/src/main/java/uk/gov/companieshouse/web/pps/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/security/WebSecurity.java
@@ -53,14 +53,6 @@ public class WebSecurity {
 
     @Bean
     @Order(5)
-    public SecurityFilterChain bankTransferSecurityFilterChain(final HttpSecurity http) throws Exception {
-        return configureWebCsrfMitigations(
-                http.securityMatcher("/pay-penalty/bank-transfer/**")
-        ).build();
-    }
-
-    @Bean
-    @Order(6)
     public SecurityFilterChain scheduledServiceDownSecurityFilterChain(final HttpSecurity http) throws Exception {
         return configureWebCsrfMitigations(
                 http.securityMatcher("/pay-penalty/unscheduled-service-down")
@@ -68,7 +60,7 @@ public class WebSecurity {
     }
 
     @Bean
-    @Order(10)
+    @Order(6)
     public SecurityFilterChain ppsWebSecurityFilterConfig(HttpSecurity http) throws Exception {
         return configureWebCsrfMitigations(
                 http.securityMatcher("/pay-penalty/**")

--- a/src/test/java/uk/gov/companieshouse/web/pps/security/WebSecurityTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/security/WebSecurityTests.java
@@ -64,13 +64,6 @@ class WebSecurityTests {
     }
 
     @Test
-    @DisplayName(" apply security filter to /pay-penalty/bank-transfer/**")
-    void bankTransferSecurityFilterChainTest() throws Exception {
-        when(httpSecurity.securityMatcher("/pay-penalty/bank-transfer/**")).thenReturn(httpSecurity);
-        assertEquals(webSecurity.bankTransferSecurityFilterChain(httpSecurity), httpSecurity.build());
-    }
-
-    @Test
     @DisplayName(" apply security filter to /pay-penalty/unscheduled-service-down")
     void scheduledServiceDownSecurityFilterChainTest() throws Exception {
         when(httpSecurity.securityMatcher("/pay-penalty/unscheduled-service-down")).thenReturn(httpSecurity);


### PR DESCRIPTION
[SAN-419](https://companieshouse.atlassian.net/browse/SAN-419) Update WebSecurity to remove old bankTransferSecurityFilterChain following recent removal of the bank-transfer pages

[SAN-419]: https://companieshouse.atlassian.net/browse/SAN-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ