### PR TITLE
SAN-420 Upgrade Spring Boot 3.4.5 to fix security issues (CVE-2025-22235, CVE-2025-22234)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <api-sdk-java.version>6.2.8</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.4.4</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.4</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.5</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.5</spring-boot-maven-plugin.version>
 
         <json.version>20241224</json.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -38,7 +38,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <hamcrest-version>3.0</hamcrest-version>
         <maven-plugin>3.5.2</maven-plugin>
-        <jib-maven-plugin>3.4.4</jib-maven-plugin>
+        <jib-maven-plugin>3.4.5</jib-maven-plugin>
         <system-stubs.version>2.1.7</system-stubs.version>
 
         <!-- sonar config -->


### PR DESCRIPTION
[SAN-420](https://companieshouse.atlassian.net/browse/SAN-420) Upgrade Spring Boot 3.4.5 to fix security issues (CVE-2025-22235, CVE-2025-22234)

Referring to https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/penalty-payment-web/jobs/dependency-check/builds/219

* https://spring.io/security/cve-2025-22235 -> spring-boot 3.4.5
* https://spring.io/security/cve-2025-22234 -> spring-security-crypto 6.4.5

See also Spring Boot 3.4.5 - https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html

[SAN-420]: https://companieshouse.atlassian.net/browse/SAN-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ