### PR TITLE
SAN-462 [Austin release 2.1] Upgrade to Spring Boot 3.5.0 (CVE-2025-22233, CVE-2025-41232)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <api-sdk-java.version>6.0.32</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.4.5</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.5</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.0</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.0</spring-boot-maven-plugin.version>
 
         <json.version>20241224</json.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -38,7 +38,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <hamcrest-version>3.0</hamcrest-version>
         <maven-plugin>3.5.2</maven-plugin>
-        <jib-maven-plugin>3.4.5</jib-maven-plugin>
+        <jib-maven-plugin>3.5.0</jib-maven-plugin>
         <system-stubs.version>2.1.7</system-stubs.version>
 
         <!-- sonar config -->


### PR DESCRIPTION
[SAN-462](https://companieshouse.atlassian.net/browse/SAN-462) Upgrade to Spring Boot 3.5.0 (CVE-2025-22233, CVE-2025-41232)
(cherry picked from commit 7a5a6cf043bbd2a48c5c23ca539ef076cb89ba1e)

[SAN-462]: https://companieshouse.atlassian.net/browse/SAN-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ