### PR TITLE
SAN-461 Upgrade commons-beanutils:1.11.0 to resolve CVE-2025-48734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <log4j-bom.version>2.24.3</log4j-bom.version>
         <common-web-java.version>3.0.33</common-web-java.version>
         <java-session-handler.version>4.1.7</java-session-handler.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <web-security-java.version>3.1.5</web-security-java.version>
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
@@ -70,6 +71,14 @@
     </dependencyManagement>
 
     <dependencies>
+        <!--the following transitive dependencies are added specifically to avoid vulnerabilities-->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${commons-beanutils.version}</version>
+        </dependency>
+        <!--end transitive dependencies-->
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>


### PR DESCRIPTION
[SAN-461](https://companieshouse.atlassian.net/browse/SAN-461) Upgrade commons-beanutils:1.11.0 to resolve CVE-2025-48734
* [penalty-payment-web/jobs/dependency-check/builds/234](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/penalty-payment-web/jobs/dependency-check/builds/234)

[SAN-461]: https://companieshouse.atlassian.net/browse/SAN-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ