### PR TITLE
SAN-484 Remove the redundant environment variable PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,41 +24,40 @@ In order to run this Web App locally you will need to install:
 
 ### Configuration
 
- Key                                                                               | Description
------------------------------------------------------------------------------------|----------------------------------------------------------------------------------
- `PPS_PAY_WEB_PORT`                                                                | The port of the penalty-payment-web application
- `HUMAN_LOG`                                                                       | For human readable logs
- `CH_BANK_ACC_NAME`                                                                | Bacs payments - Account name (late filing penalty: A)
- `CH_BANK_SORT_CODE`                                                               | Bacs payments - Sort code (late filing penalty: A)
- `CH_BANK_ACC_NUM`                                                                 | Bacs payments - Account number (late filing penalty: A)
- `CH_BANK_IBAN`                                                                    | Overseas payments - IBAN (late filing penalty: A)
- `CH_BANK_SWIFT_CODE`                                                              | Overseas payments - SWIFT code (late filing penalty: A)
- `CH_SANCTIONS_BANK_ACC_NAME`                                                      | Bacs payments - Account name (sanction: P)
- `CH_SANCTIONS_BANK_SORT_CODE`                                                     | Bacs payments - Sort code (sanction: P)
- `CH_SANCTIONS_BANK_ACC_NUM`                                                       | Bacs payments - Account number (sanction: P)
- `CH_SANCTIONS_BANK_IBAN`                                                          | Overseas payments - IBAN (sanction: P)
- `CH_SANCTIONS_BANK_SWIFT_CODE`                                                    | Overseas payments - SWIFT code (sanction: P)
- `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224`                               | Feature flag to enable Penalty Payment for Sanctions
- `PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID`                                 | Matomo Goal Id: PAY A PENALTY - Start Now Button
- `PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID`                              | Matomo Goal Id: PAY A PENALTY - Pay another penalty
- `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_LFP_GOAL_ID`                      | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with LFP A
- `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_SANCTIONS_GOAL_ID`                | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with Sanctions P
- `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_LFP_GOAL_ID`                     | Matomo Goal Id: PAY A PENALTY - Penalty details continue button A
- `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_SANCTIONS_GOAL_ID`               | Matomo Goal Id: PAY A PENALTY - Penalty details continue button P
- `PENALTY_PAYMENT_MATOMO_PENALTY_IN_DCA_STOP_SCREEN_GOAL_ID`                       | Matomo Goal Id: PAY A PENALTY - Penalty in DCA Stop Screen
- `PENALTY_PAYMENT_MATOMO_PENALTY_PAYMENT_IN_PROGRESS_STOP_SCREEN_GOAL_ID`          | Matomo Goal Id: PAY A PENALTY - Penalty Payment in Progress Stop Screen
- `PENALTY_PAYMENT_MATOMO_UNSCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`             | Matomo Goal Id: PAY A PENALTY - Unscheduled Service Down Stop Screen
- `PENALTY_PAYMENT_MATOMO_SCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`               | Matomo Goal Id: PAY A PENALTY - Scheduled Service Down Stop Screen
- `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_LFP_STOP_SCREEN_GOAL_ID`       | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable LFP Stop Screen
- `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_SANCTIONS_STOP_SCREEN_GOAL_ID` | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable Sanctions Stop Screen
- `GOV_UK_PAY_PENALTY_URL`                                                          | GOV.UK service banner URL: Pay a penalty to Companies House
+| Key                                                                               | Description                                                                      |
+|-----------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `PPS_PAY_WEB_PORT`                                                                | The port of the penalty-payment-web application                                  |
+| `HUMAN_LOG`                                                                       | For human readable logs                                                          |
+| `CH_BANK_ACC_NAME`                                                                | Bacs payments - Account name (late filing penalty: A)                            |
+| `CH_BANK_SORT_CODE`                                                               | Bacs payments - Sort code (late filing penalty: A)                               |
+| `CH_BANK_ACC_NUM`                                                                 | Bacs payments - Account number (late filing penalty: A)                          |
+| `CH_BANK_IBAN`                                                                    | Overseas payments - IBAN (late filing penalty: A)                                |
+| `CH_BANK_SWIFT_CODE`                                                              | Overseas payments - SWIFT code (late filing penalty: A)                          |
+| `CH_SANCTIONS_BANK_ACC_NAME`                                                      | Bacs payments - Account name (sanction: P)                                       |
+| `CH_SANCTIONS_BANK_SORT_CODE`                                                     | Bacs payments - Sort code (sanction: P)                                          |
+| `CH_SANCTIONS_BANK_ACC_NUM`                                                       | Bacs payments - Account number (sanction: P)                                     |
+| `CH_SANCTIONS_BANK_IBAN`                                                          | Overseas payments - IBAN (sanction: P)                                           |
+| `CH_SANCTIONS_BANK_SWIFT_CODE`                                                    | Overseas payments - SWIFT code (sanction: P)                                     |
+| `FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224`                               | Feature flag to enable Penalty Payment for Sanctions                             |
+| `PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID`                              | Matomo Goal Id: PAY A PENALTY - Pay another penalty                              |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_LFP_GOAL_ID`                      | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with LFP A                    |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_SANCTIONS_GOAL_ID`                | Matomo Goal Id: PAY A PENALTY - Penalty ref starts with Sanctions P              |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_LFP_GOAL_ID`                     | Matomo Goal Id: PAY A PENALTY - Penalty details continue button A                |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_DETAILS_CONTINUE_SANCTIONS_GOAL_ID`               | Matomo Goal Id: PAY A PENALTY - Penalty details continue button P                |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_IN_DCA_STOP_SCREEN_GOAL_ID`                       | Matomo Goal Id: PAY A PENALTY - Penalty in DCA Stop Screen                       |
+| `PENALTY_PAYMENT_MATOMO_PENALTY_PAYMENT_IN_PROGRESS_STOP_SCREEN_GOAL_ID`          | Matomo Goal Id: PAY A PENALTY - Penalty Payment in Progress Stop Screen          |
+| `PENALTY_PAYMENT_MATOMO_UNSCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`             | Matomo Goal Id: PAY A PENALTY - Unscheduled Service Down Stop Screen             |
+| `PENALTY_PAYMENT_MATOMO_SCHEDULED_SERVICE_DOWN_STOP_SCREEN_GOAL_ID`               | Matomo Goal Id: PAY A PENALTY - Scheduled Service Down Stop Screen               |
+| `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_LFP_STOP_SCREEN_GOAL_ID`       | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable LFP Stop Screen       |
+| `PENALTY_PAYMENT_MATOMO_ONLINE_PAYMENT_UNAVAILABLE_SANCTIONS_STOP_SCREEN_GOAL_ID` | Matomo Goal Id: PAY A PENALTY - Online Payment Unavailable Sanctions Stop Screen |
+| `GOV_UK_PAY_PENALTY_URL`                                                          | GOV.UK service banner URL: Pay a penalty to Companies House                      |
 
 ### Web Pages
 
- Page                                        | Address
----------------------------------------------|--------------------------------
- Start page for Penalty Payment Service      | `/pay-penalty`
- What does the penalty reference start with? | `/pay-penalty/ref-starts-with`
+| Page                                        | Address                        |
+|---------------------------------------------|--------------------------------|
+| Start page for Penalty Payment Service      | `/pay-penalty`                 |
+| What does the penalty reference start with? | `/pay-penalty/ref-starts-with` |
 
 ## Terraform ECS
 
@@ -67,11 +66,11 @@ In order to run this Web App locally you will need to install:
 The code present in this repository is used to define and deploy a dockerised container in AWS ECS.
 This is done by calling a [module](https://github.com/companieshouse/terraform-modules/tree/main/aws/ecs) from terraform-modules. Application specific attributes are injected and the service is then deployed using Terraform via the CICD platform 'Concourse'.
 
- Application specific attributes | Value                                                                                                                                                                                                                                                      | Description                                         
-:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------
- **ECS Cluster**                 | company-requests                                                                                                                                                                                                                                           | ECS cluster (stack) the service belongs to          
- **Load balancer**               | {env}-chs-chgovuk                                                                                                                                                                                                                                          | The load balancer that sits in front of the service 
- **Concourse pipeline**          | [Pipeline link](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/penalty-payment-web) <br> [Pipeline code](https://github.com/companieshouse/ci-pipelines/blob/master/pipelines/ssplatform/team-development/penalty-payment-web) | Concourse pipeline link in shared services          
+| Application specific attributes | Value                                                                                                                                                                                                                                                      | Description                                         |
+|:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------|
+| **ECS Cluster**                 | company-requests                                                                                                                                                                                                                                           | ECS cluster (stack) the service belongs to          |
+| **Load balancer**               | {env}-chs-chgovuk                                                                                                                                                                                                                                          | The load balancer that sits in front of the service |
+| **Concourse pipeline**          | [Pipeline link](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/penalty-payment-web) <br> [Pipeline code](https://github.com/companieshouse/ci-pipelines/blob/master/pipelines/ssplatform/team-development/penalty-payment-web) | Concourse pipeline link in shared services          |
 
 ### Contributing
 - Please refer to the [ECS Development and Infrastructure Documentation](https://companieshouse.atlassian.net/wiki/spaces/DEVOPS/pages/4390649858/Copy+of+ECS+Development+and+Infrastructure+Documentation+Updated) for detailed information on the infrastructure being deployed.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,6 @@ enquiries=mailto:enquiries@companieshouse.gov.uk
 feature-flag.penalty-ref-enabled.SANCTIONS=${FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_191224:false}
 feature-flag.penalty-ref-enabled.SANCTIONS_ROE=${FEATURE_FLAG_PENALTY_REF_ENABLED_SANCTIONS_ROE_290525:false}
 
-matomo.start-now-button-goal-id=${PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID}
 matomo.pay-another-penalty-goal-id=${PENALTY_PAYMENT_MATOMO_PAY_ANOTHER_PENALTY_GOAL_ID}
 matomo.penalty-ref-starts-with-lfp-goal-id=${PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_LFP_GOAL_ID}
 matomo.penalty-ref-starts-with-sanctions-goal-id=${PENALTY_PAYMENT_MATOMO_PENALTY_REF_STARTS_WITH_SANCTIONS_GOAL_ID}


### PR DESCRIPTION
[SAN-484](https://companieshouse.atlassian.net/browse/SAN-484) Remove the redundant environment variable PENALTY_PAYMENT_MATOMO_START_NOW_BUTTON_GOAL_ID

[SAN-484]: https://companieshouse.atlassian.net/browse/SAN-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ