### PR TITLE
SAN-31-Penalty-summary-ROE

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/ViewPenaltiesController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/ViewPenaltiesController.java
@@ -124,6 +124,7 @@ public class ViewPenaltiesController extends BaseController {
             return REDIRECT_URL_PREFIX + penaltyConfigurationProperties.getUnscheduledServiceDownPath();
         }
 
+        model.addAttribute("penaltyReferenceName", penaltyReference.name());
         model.addAttribute(COMPANY_NAME_ATTR, companyProfileApi.getCompanyName());
         model.addAttribute(PENALTY_REF_ATTR, penaltyRef);
         model.addAttribute(REASON_ATTR, payablePenalty.getReason());

--- a/src/main/resources/locales/messages.properties
+++ b/src/main/resources/locales/messages.properties
@@ -23,6 +23,7 @@ viewPenalties.penalty-summary-title=Penalty summary
 viewPenalties.penalty-ref-label=Penalty reference
 viewPenalties.reason-for-penalty-label=Reason for penalty
 viewPenalties.company-number-label=Company number
+viewPenalties.company-number-label-ROE=Overseas Entity ID
 viewPenalties.issued-to-label=Issued to
 viewPenalties.amount-label=Amount
 

--- a/src/main/resources/templates/pps/viewPenalties.html
+++ b/src/main/resources/templates/pps/viewPenalties.html
@@ -23,7 +23,9 @@
                         <dd class="govuk-summary-list__value" th:text="${companyName}"></dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key" th:text="#{viewPenalties.company-number-label}"></dt>
+                        <dt class="govuk-summary-list__key"
+                            th:text="${penaltyReferenceName == 'SANCTIONS_ROE'} ? #{viewPenalties.company-number-label-ROE} : #{viewPenalties.company-number-label}">
+                        </dt>
                         <dd class="govuk-summary-list__value" th:text="${companyNumber}"></dd>
                     </div>
                     <div class="govuk-summary-list__row">

--- a/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/ViewPenaltiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/controller/pps/ViewPenaltiesControllerTest.java
@@ -119,7 +119,8 @@ class ViewPenaltiesControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NAME_ATTR))
                 .andExpect(model().attributeExists(PENALTY_REF_ATTR))
                 .andExpect(model().attributeExists(REASON_ATTR))
-                .andExpect(model().attributeExists(AMOUNT_ATTR));
+                .andExpect(model().attributeExists(AMOUNT_ATTR))
+                .andExpect(model().attributeExists("penaltyReferenceName"));
 
         verify(mockFeatureFlagChecker).isPenaltyRefEnabled(LATE_FILING);
         verify(mockCompanyService).getCompanyProfile(COMPANY_NUMBER);
@@ -144,7 +145,8 @@ class ViewPenaltiesControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NAME_ATTR))
                 .andExpect(model().attributeExists(PENALTY_REF_ATTR))
                 .andExpect(model().attributeExists(REASON_ATTR))
-                .andExpect(model().attributeExists(AMOUNT_ATTR));
+                .andExpect(model().attributeExists(AMOUNT_ATTR))
+                .andExpect(model().attributeExists("penaltyReferenceName"));
 
         verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
         verify(mockCompanyService).getCompanyProfile(COMPANY_NUMBER);
@@ -246,7 +248,8 @@ class ViewPenaltiesControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NAME_ATTR))
                 .andExpect(model().attributeExists(PENALTY_REF_ATTR))
                 .andExpect(model().attributeExists(REASON_ATTR))
-                .andExpect(model().attributeExists(AMOUNT_ATTR));
+                .andExpect(model().attributeExists(AMOUNT_ATTR))
+                .andExpect(model().attributeExists("penaltyReferenceName"));
 
         verify(mockFeatureFlagChecker).isPenaltyRefEnabled(SANCTIONS);
         verify(mockCompanyService).getCompanyProfile(COMPANY_NUMBER);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/SAN-31

Linked to:
https://companieshouse.atlassian.net/browse/SAN-466


Updating penalty summary page to display "Overseas Entity ID" instead of "Company Number" for ROE penalties.