### PR TITLE
SAN-500 Upgrade to Spring Boot v3.5.3 (CVE-2025-41234, CVE-2025-48988, CVE-2025-49125)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <api-sdk-java.version>6.3.0</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.5.0</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.0</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.3</spring-boot-maven-plugin.version>
 
         <json.version>20241224</json.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -39,7 +39,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <hamcrest-version>3.0</hamcrest-version>
         <maven-plugin>3.5.2</maven-plugin>
-        <jib-maven-plugin>3.5.0</jib-maven-plugin>
+        <jib-maven-plugin>3.5.3</jib-maven-plugin>
         <system-stubs.version>2.1.7</system-stubs.version>
 
         <!-- sonar config -->


### PR DESCRIPTION
SAN-500 Upgrade to Spring Boot v3.5.3 (CVE-2025-41234, CVE-2025-48988, CVE-2025-49125)
* spring-web 6.2.8 (CVE-2025-41234)
* tomcat-embed-core 10.1.42 (CVE-2025-48988, CVE-2025-49125)