### PR TITLE
SAN-553 CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <junit-jupiter-engine.version>5.11.4</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
         <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
-        <api-sdk-java.version>6.3.4</api-sdk-java.version>
+        <api-sdk-java.version>6.3.5</api-sdk-java.version>
 
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
         <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>


### PR DESCRIPTION
SAN-553
CVE-2024-7246 - grpc-api dependency update
Update version api-sdk-java
https://companieshouse.atlassian.net/browse/SAN-553