### PR TITLE
SAN-556-Missing-Sign-Out-Bug

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltyrefstartswith/impl/PenaltyRefStartsWithServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltyrefstartswith/impl/PenaltyRefStartsWithServiceImpl.java
@@ -20,7 +20,6 @@ import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.AVAILABLE_PENALTY_REF_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.BACK_LINK_URL_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.PENALTY_REFERENCE_CHOICE_ATTR;
-import static uk.gov.companieshouse.web.pps.service.ServiceConstants.SIGN_OUT_URL_ATTR;
 
 @Service
 public class PenaltyRefStartsWithServiceImpl implements PenaltyRefStartsWithService {
@@ -120,7 +119,6 @@ public class PenaltyRefStartsWithServiceImpl implements PenaltyRefStartsWithServ
     private Map<String, String> setBackUrl() {
         Map<String, String> baseModelAttributes = new HashMap<>();
         baseModelAttributes.put(BACK_LINK_URL_ATTR, penaltyConfigurationProperties.getStartPath());
-        baseModelAttributes.put(SIGN_OUT_URL_ATTR, penaltyConfigurationProperties.getSignOutPath());
         return baseModelAttributes;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltyrefstartswith/impl/PenaltyRefStartsWithServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltyrefstartswith/impl/PenaltyRefStartsWithServiceImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.AVAILABLE_PENALTY_REF_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.BACK_LINK_URL_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.PENALTY_REFERENCE_CHOICE_ATTR;
+import static uk.gov.companieshouse.web.pps.service.ServiceConstants.SIGN_OUT_URL_ATTR;
 
 @Service
 public class PenaltyRefStartsWithServiceImpl implements PenaltyRefStartsWithService {
@@ -119,6 +120,7 @@ public class PenaltyRefStartsWithServiceImpl implements PenaltyRefStartsWithServ
     private Map<String, String> setBackUrl() {
         Map<String, String> baseModelAttributes = new HashMap<>();
         baseModelAttributes.put(BACK_LINK_URL_ATTR, penaltyConfigurationProperties.getStartPath());
+        baseModelAttributes.put(SIGN_OUT_URL_ATTR, penaltyConfigurationProperties.getSignOutPath());
         return baseModelAttributes;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/pps/service/viewpenalty/impl/ViewPenaltiesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/viewpenalty/impl/ViewPenaltiesServiceImpl.java
@@ -35,6 +35,7 @@ import static uk.gov.companieshouse.web.pps.service.ServiceConstants.COMPANY_NAM
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.PENALTY_REFERENCE_NAME_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.PENALTY_REF_ATTR;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.REASON_ATTR;
+import static uk.gov.companieshouse.web.pps.service.ServiceConstants.SIGN_OUT_URL_ATTR;
 import static uk.gov.companieshouse.web.pps.service.penaltypayment.impl.PenaltyPaymentServiceImpl.PENALTY_TYPE;
 
 @Service
@@ -241,6 +242,7 @@ public class ViewPenaltiesServiceImpl implements ViewPenaltiesService {
         String redirectBackUrl = penaltyConfigurationProperties.getEnterDetailsPath()
                 + "?ref-starts-with=" + penaltyReference.getStartsWith();
         baseModelAttributes.put(BACK_LINK_URL_ATTR, redirectBackUrl);
+        baseModelAttributes.put(SIGN_OUT_URL_ATTR, penaltyConfigurationProperties.getSignOutPath());
         serviceResponse.setBaseModelAttributes(baseModelAttributes);
     }
 


### PR DESCRIPTION
Adding the sign out option back into penalty summary page, not needed for penalty ref starts with page:
https://companieshouse.atlassian.net/browse/SAN-556