### PR TITLE
SAN-597 Address the issue with paid penalty with associated costs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImpl.java
@@ -72,29 +72,34 @@ public class PenaltyPaymentServiceImpl implements PenaltyPaymentService {
         LOGGER.debug(String.format("[%s]: Request to fetch financial penalties successful for company number %s and penalty ref %s",
                 requestId, companyNumber, penaltyRef));
 
-        var penaltyOrUnpaidItems = financialPenalties.getItems().stream()
+        var penaltyAndAssociatedCosts = financialPenalties.getItems().stream()
                 .filter(financialPenalty -> penaltyRef.equals(financialPenalty.getId())
                         || FALSE.equals(financialPenalty.getPaid()))
                 .toList();
-        LOGGER.debug(String.format("[%s]: %d Penalty or unpaid items for company number %s and penalty ref %s",
-                requestId, penaltyOrUnpaidItems.size(), companyNumber, penaltyRef));
+        LOGGER.debug(String.format("[%s]: %d Penalty and associated costs for company number %s and penalty ref %s",
+                requestId, penaltyAndAssociatedCosts.size(), companyNumber, penaltyRef));
 
-        Optional<FinancialPenalty> penaltyOptional = penaltyOrUnpaidItems.stream()
+        Optional<FinancialPenalty> penaltyOptional = penaltyAndAssociatedCosts.stream()
                 .filter(financialPenalty -> penaltyRef.equals(financialPenalty.getId()))
                 .filter(financialPenalty -> PENALTY_TYPE.equals(financialPenalty.getType()))
                 .findFirst();
 
         if (penaltyOptional.isPresent()) {
             FinancialPenalty penalty = penaltyOptional.get();
-            var unpaidLegalCosts = penaltyOrUnpaidItems.stream()
-                    .filter(financialPenalty -> OTHER_TYPE.equals(financialPenalty.getType()))
-                    .filter(financialPenalty -> penaltyRef.equals(financialPenalty.getId())
-                            || penalty.getMadeUpDate().equals(financialPenalty.getMadeUpDate()))
-                    .toList();
-
             var penaltyAndCosts = new ArrayList<FinancialPenalty>();
             penaltyAndCosts.add(penalty);
-            penaltyAndCosts.addAll(unpaidLegalCosts);
+            if (FALSE.equals(penalty.getPaid())) {
+                // Include associated costs only if penalty is unpaid. This is to ensure that decision is not made
+                // based on the associated costs for paid penalties.
+                // If penalty is already paid, we only need to tell the user that the penalty is already paid.
+                var associatedCosts = penaltyAndAssociatedCosts.stream()
+                        .filter(financialPenalty -> OTHER_TYPE.equals(financialPenalty.getType()))
+                        .filter(financialPenalty -> penaltyRef.equals(financialPenalty.getId())
+                                || penalty.getMadeUpDate().equals(financialPenalty.getMadeUpDate()))
+                        .toList();
+
+                penaltyAndCosts.addAll(associatedCosts);
+            }
 
             LOGGER.debug(String.format("[%s]: %d Penalty and costs for company number %s and penalty ref %s",
                     requestId, penaltyAndCosts.size(), companyNumber, penaltyRef));

--- a/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/pps/service/penaltypayment/impl/PenaltyPaymentServiceImplTest.java
@@ -301,9 +301,34 @@ class PenaltyPaymentServiceImplTest {
         );
 
         List<FinancialPenalty> payableFinancialPenalties =
-                penaltyPaymentService.getFinancialPenalties(COMPANY_NUMBER, PENALTY_REF_TWO);
+                penaltyPaymentService.getFinancialPenalties(COMPANY_NUMBER, PENALTY_REF);
 
-        assertEquals(0, payableFinancialPenalties.size());
+        assertEquals(1, payableFinancialPenalties.size());
+    }
+
+    @Test
+    @DisplayName("Get payable financial penalties - Paid Penalty with associated costs")
+    void getPayableFinancialPenaltiesPaidWithAssociatedCostPenalty()
+            throws ServiceException, ApiErrorResponseException, URIValidationException {
+        when(apiClient.financialPenalty()).thenReturn(financialPenaltyResourceHandler);
+
+        String uri = "/company/" + COMPANY_NUMBER + "/penalties/" + LATE_FILING;
+        String madeUpDate = now().minusYears(1).toString();
+        FinancialPenalty paidFinancialPenalty = PPSTestUtility.paidFinancialPenalty(
+                PENALTY_REF, madeUpDate);
+        FinancialPenalty associatedCosts = PPSTestUtility.notPenaltyTypeFinancialPenalty(PENALTY_REF, madeUpDate);
+
+        when(financialPenaltyResourceHandler.get(uri)).thenReturn(financialPenaltiesGet);
+        when(financialPenaltiesGet.execute()).thenReturn(responseWithData);
+
+        when(responseWithData.getData()).thenReturn(
+                PPSTestUtility.twoFinancialPenalties(paidFinancialPenalty, associatedCosts)
+        );
+
+        List<FinancialPenalty> payableFinancialPenalties =
+                penaltyPaymentService.getFinancialPenalties(COMPANY_NUMBER, PENALTY_REF);
+
+        assertEquals(1, payableFinancialPenalties.size());
     }
 
     @Test


### PR DESCRIPTION
When a call to fetch penalties for a given penalty ref returns a paid penalty and an associated cost with the same ID, the user is redirected to pay by BACS page as payment for penalties with associated costs are not processed by PPS.
However, since the penalty is already paid, we expect to see the message that the penalty is already paid.
This patch applies the required fix that enables the expected message already paid penalties to be presented to the user.