### PR TITLE
SAN-666 Fix jib-maven-plugin version: 3.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <hamcrest-version>3.0</hamcrest-version>
         <maven-plugin>3.5.2</maven-plugin>
-        <jib-maven-plugin>3.5.4</jib-maven-plugin>
+        <jib-maven-plugin>3.4.6</jib-maven-plugin>
         <system-stubs.version>2.1.7</system-stubs.version>
 
         <!-- sonar config -->


### PR DESCRIPTION
[SAN-666](https://companieshouse.atlassian.net/browse/SAN-666) Fix jib-maven-plugin version: 3.4.6

[SAN-666]: https://companieshouse.atlassian.net/browse/SAN-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ