### PR TITLE
ASM-2091: Fix for confirmation page to address Thymeleaf TemplateProcessingException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
     <properties>
         <java.version>21</java.version>
-        <structured-logging.version>3.0.42</structured-logging.version>
+        <structured-logging.version>3.0.55</structured-logging.version>
         <log4j-bom.version>2.25.4</log4j-bom.version>
         <common-web-java.version>4.1.5</common-web-java.version>
         <java-session-handler.version>4.1.15</java-session-handler.version>
@@ -105,6 +105,11 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-el</artifactId>
             <version>${tomcat.version}</version>
         </dependency>
         <!--end transitive dependencies-->

--- a/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/ConfirmationController.java
+++ b/src/main/java/uk/gov/companieshouse/web/pps/controller/pps/ConfirmationController.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.web.pps.service.confirmation.ConfirmationService;
 import uk.gov.companieshouse.web.pps.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.pps.service.response.PPSServiceResponse;
 import uk.gov.companieshouse.web.pps.session.SessionService;
+import org.springframework.beans.factory.annotation.Value;
 
 import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
 import static uk.gov.companieshouse.web.pps.service.ServiceConstants.SIGN_OUT_URL_ATTR;
@@ -26,6 +27,12 @@ public class ConfirmationController extends BaseController {
     static final String CONFIRMATION_PAGE_TEMPLATE_NAME = "pps/confirmationPage";
 
     private final ConfirmationService confirmationService;
+
+    @Value("${penalty.ref-starts-with-url}")
+    private String payAnotherPenaltyUrl;
+
+    @Value("${matomo.pay-another-penalty-goal-id}")
+    private Integer payAnotherPenaltyGoalId;
 
     public ConfirmationController(
             NavigatorService navigatorService,
@@ -73,6 +80,9 @@ public class ConfirmationController extends BaseController {
                             model,
                             sessionService.getSessionDataFromContext(),
                             serviceResponse.getBaseModelAttributes().get().get(SIGN_OUT_URL_ATTR)));
+
+            model.addAttribute("payAnotherPenaltyUrl", payAnotherPenaltyUrl);
+            model.addAttribute("payAnotherPenaltyGoalId", payAnotherPenaltyGoalId);
 
             return serviceResponse.getUrl().orElse(getTemplateName());
 

--- a/src/main/resources/templates/pps/confirmationPage.html
+++ b/src/main/resources/templates/pps/confirmationPage.html
@@ -120,10 +120,10 @@
                 <p class="govuk-body">
                     You can use this service again to
                     <a id="penalty-ref-starts-with-link"
-                       th:href="${@environment.getProperty('penalty.ref-starts-with-url')}"
+                       th:href="${payAnotherPenaltyUrl}"
                        class="govuk-link"
                        data-event-id="Pay another penalty link"
-                       th:onclick="_paq.push(['trackGoal', [[${@environment.getProperty('matomo.pay-another-penalty-goal-id')}]]]);">
+                       th:onclick="|_paq.push(['trackGoal', ${payAnotherPenaltyGoalId}]);|">
                     pay another penalty</a>.
                 </p>
                 <br><br>


### PR DESCRIPTION
**Why this change:**

After dependency upgrades (Spring Boot/Thymeleaf stack), rendering pps/confirmationPage failed with:
TemplateProcessingException: Instantiation of new objects and access to static classes or parameters is forbidden in this context

The failure was triggered by template expressions calling @environment.getProperty(...) directly in th:href / th:onclick in src/main/resources/templates/pps/confirmationPage.html.

**What changed:** 

Updated src/main/resources/templates/pps/confirmationPage.html to stop reading properties directly from @environment in the template.
Updated src/main/java/uk/gov/companieshouse/web/pps/controller/pps/ConfirmationController.java to pass required values as model attributes:
pay another penalty URL
Matomo goal id

Associated ticket: 
https://companieshouse.atlassian.net/browse/ASM-2091